### PR TITLE
feat: add file logging for release builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@praha/byethrow": "^0.10.1",
     "@tanstack/react-query": "^5.95.2",
     "@tauri-apps/api": "^2",
+    "@tauri-apps/plugin-opener": "^2.5.3",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       '@tauri-apps/api':
         specifier: ^2
         version: 2.10.1
+      '@tauri-apps/plugin-opener':
+        specifier: ^2.5.3
+        version: 2.5.3
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -1431,6 +1434,9 @@ packages:
     resolution: {integrity: sha512-jQNGF/5quwORdZSSLtTluyKQ+o6SMa/AUICfhf4egCGFdMHqWssApVgYSbg+jmrZoc8e1DscNvjTnXtlHLS11g==}
     engines: {node: '>= 10'}
     hasBin: true
+
+  '@tauri-apps/plugin-opener@2.5.3':
+    resolution: {integrity: sha512-CCcUltXMOfUEArbf3db3kCE7Ggy1ExBEBl51Ko2ODJ6GDYHRp1nSNlQm5uNCFY5k7/ufaK5Ib3Du/Zir19IYQQ==}
 
   '@testing-library/dom@10.4.1':
     resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
@@ -4645,6 +4651,10 @@ snapshots:
       '@tauri-apps/cli-win32-arm64-msvc': 2.10.1
       '@tauri-apps/cli-win32-ia32-msvc': 2.10.1
       '@tauri-apps/cli-win32-x64-msvc': 2.10.1
+
+  '@tauri-apps/plugin-opener@2.5.3':
+    dependencies:
+      '@tauri-apps/api': 2.10.1
 
   '@testing-library/dom@10.4.1':
     dependencies:

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -10,6 +10,17 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "ahash"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
+dependencies = [
+ "getrandom 0.2.17",
+ "once_cell",
+ "version_check",
+]
+
+[[package]]
+name = "ahash"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
@@ -58,6 +69,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "android_log-sys"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84521a3cf562bc62942e294181d9eef17eb38ceb8c68677bc49f144e4c3d4f8d"
+
+[[package]]
+name = "android_logger"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbb4e440d04be07da1f1bf44fb4495ebd58669372fe0cffa6e48595ac5bd88a3"
+dependencies = [
+ "android_log-sys",
+ "env_filter",
+ "log",
+]
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -101,6 +129,12 @@ dependencies = [
  "wl-clipboard-rs",
  "x11rb",
 ]
+
+[[package]]
+name = "arrayvec"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "assert-json-diff"
@@ -321,6 +355,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "bitvec"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
+dependencies = [
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
+]
+
+[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -352,6 +398,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "borsh"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfd1e3f8955a5d7de9fab72fc8373fade9fb8a703968cb200ae3dc6cf08e185a"
+dependencies = [
+ "borsh-derive",
+ "bytes",
+ "cfg_aliases",
+]
+
+[[package]]
+name = "borsh-derive"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfcfdc083699101d5a7965e49925975f2f55060f94f9a05e7187be95d530ca59"
+dependencies = [
+ "once_cell",
+ "proc-macro-crate 3.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "brotli"
 version = "8.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -377,6 +447,40 @@ name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+
+[[package]]
+name = "byte-unit"
+version = "5.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c6d47a4e2961fb8721bcfc54feae6455f2f64e7054f9bc67e875f0e77f4c58d"
+dependencies = [
+ "rust_decimal",
+ "schemars 1.2.1",
+ "serde",
+ "utf8-width",
+]
+
+[[package]]
+name = "bytecheck"
+version = "0.6.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23cdc57ce23ac53c931e88a43d06d070a6fd142f2617be5855eb75efc9beb1c2"
+dependencies = [
+ "bytecheck_derive",
+ "ptr_meta",
+ "simdutf8",
+]
+
+[[package]]
+name = "bytecheck_derive"
+version = "0.6.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3db406d29fbcd95542e92559bed4d8ad92636d1ca8b3b72ede10b4bcc010e659"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
 
 [[package]]
 name = "bytemuck"
@@ -514,6 +618,12 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
@@ -1045,6 +1155,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "env_filter"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bf3c259d255ca70051b30e2e95b5446cdb8949ac4cd22c0d7fd634d89f568e2"
+dependencies = [
+ "log",
+ "regex",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1163,6 +1283,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "fern"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4316185f709b23713e41e3195f90edef7fb00c3ed4adc79769cf09cc762a3b29"
+dependencies = [
+ "log",
+]
+
+[[package]]
 name = "field-offset"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1273,6 +1402,12 @@ checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
 ]
+
+[[package]]
+name = "funty"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futf"
@@ -1743,6 +1878,9 @@ name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+dependencies = [
+ "ahash 0.7.8",
+]
 
 [[package]]
 name = "hashbrown"
@@ -1750,7 +1888,7 @@ version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 dependencies = [
- "ahash",
+ "ahash 0.8.12",
 ]
 
 [[package]]
@@ -2439,6 +2577,9 @@ name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+dependencies = [
+ "value-bag",
+]
 
 [[package]]
 name = "mac"
@@ -2750,6 +2891,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "num_threads"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -3475,6 +3625,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ptr_meta"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0738ccf7ea06b608c10564b31debd4f5bc5e197fc8bfe088f68ae5ce81e7a4f1"
+dependencies = [
+ "ptr_meta_derive",
+]
+
+[[package]]
+name = "ptr_meta_derive"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16b845dbfca988fa33db069c0e230574d15a3088f147a87b64c7589eb662c9ac"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "pxfm"
 version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3543,6 +3713,12 @@ name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "radium"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
@@ -3739,6 +3915,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
+name = "rend"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71fe3824f5629716b1589be05dacd749f6aa084c87e00e016714a8cdfccc997c"
+dependencies = [
+ "bytecheck",
+]
+
+[[package]]
 name = "reqwest"
 version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3832,6 +4017,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "rkyv"
+version = "0.7.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2297bf9c81a3f0dc96bc9521370b88f054168c29826a75e89c55ff196e7ed6a1"
+dependencies = [
+ "bitvec",
+ "bytecheck",
+ "bytes",
+ "hashbrown 0.12.3",
+ "ptr_meta",
+ "rend",
+ "rkyv_derive",
+ "seahash",
+ "tinyvec",
+ "uuid",
+]
+
+[[package]]
+name = "rkyv_derive"
+version = "0.7.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84d7b42d4b8d06048d3ac8db0eb31bcb942cbeb709f0b5f2b2ebde398d3038f5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "rusqlite"
 version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3843,6 +4057,23 @@ dependencies = [
  "hashlink",
  "libsqlite3-sys",
  "smallvec",
+]
+
+[[package]]
+name = "rust_decimal"
+version = "1.41.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ce901f9a19d251159075a4c37af514c3b8ef99c22e02dd8c19161cf397ee94a"
+dependencies = [
+ "arrayvec",
+ "borsh",
+ "bytes",
+ "num-traits",
+ "rand 0.8.5",
+ "rkyv",
+ "serde",
+ "serde_json",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -4032,6 +4263,12 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "seahash"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
 
 [[package]]
 name = "security-framework"
@@ -4338,6 +4575,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
 
 [[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
 name = "similar"
 version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4629,6 +4872,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
+
+[[package]]
 name = "tar"
 version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4790,6 +5039,29 @@ dependencies = [
  "tauri",
  "tauri-plugin",
  "thiserror 2.0.18",
+]
+
+[[package]]
+name = "tauri-plugin-log"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7545bd67f070a4500432c826e2e0682146a1d6712aee22a2786490156b574d93"
+dependencies = [
+ "android_logger",
+ "byte-unit",
+ "fern",
+ "log",
+ "objc2",
+ "objc2-foundation",
+ "serde",
+ "serde_json",
+ "serde_repr",
+ "swift-rs",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.18",
+ "time",
+ "tracing",
 ]
 
 [[package]]
@@ -5052,7 +5324,9 @@ checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
  "itoa",
+ "libc",
  "num-conv",
+ "num_threads",
  "powerfmt",
  "serde_core",
  "time-core",
@@ -5084,6 +5358,21 @@ dependencies = [
  "displaydoc",
  "zerovec",
 ]
+
+[[package]]
+name = "tinyvec"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
@@ -5430,6 +5719,7 @@ dependencies = [
  "futures",
  "hex",
  "keyring",
+ "log",
  "mockito",
  "objc2-web-kit",
  "open",
@@ -5442,6 +5732,7 @@ dependencies = [
  "tauri",
  "tauri-build",
  "tauri-plugin-clipboard-manager",
+ "tauri-plugin-log",
  "tauri-plugin-opener",
  "tauri-plugin-updater",
  "tempfile",
@@ -5549,6 +5840,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
+name = "utf8-width"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1292c0d970b54115d14f2492fe0170adf21d68a1de108eebc51c1df4f346a091"
+
+[[package]]
 name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5571,6 +5868,12 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "value-bag"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ba6f5989077681266825251a52748b8c1d8a4ad098cc37e440103d0ea717fc0"
 
 [[package]]
 name = "vcpkg"
@@ -6600,6 +6903,15 @@ dependencies = [
  "windows-core 0.61.2",
  "windows-version",
  "x11-dl",
+]
+
+[[package]]
+name = "wyz"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
+dependencies = [
+ "tap",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -14,6 +14,7 @@ tauri-build = { version = "2", features = [] }
 [dependencies]
 tauri = { version = "2", features = ["image-png", "unstable"] }
 tauri-plugin-clipboard-manager = "2"
+tauri-plugin-log = { version = "2", features = ["tracing"] }
 tauri-plugin-opener = "2"
 tauri-plugin-updater = "2"
 serde = { version = "1", features = ["derive"] }
@@ -27,6 +28,7 @@ chrono = { version = "0.4", features = ["serde"] }
 uuid = { version = "1", features = ["v4"] }
 sha2 = "0.10"
 hex = "0.4"
+log = "0.4"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 keyring = { version = "3", features = ["apple-native", "sync-secret-service"] }

--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -1,3 +1,77 @@
+#[cfg(windows)]
+fn copy_webview2_loader() {
+    use std::fs;
+    use std::path::PathBuf;
+
+    let out_dir = PathBuf::from(std::env::var("OUT_DIR").expect("OUT_DIR should be set"));
+    let Some(profile_dir) = out_dir.ancestors().find(|path| {
+        path.file_name()
+            .is_some_and(|name| name == "debug" || name == "release")
+    }) else {
+        println!("cargo:warning=Could not determine Cargo profile directory from OUT_DIR");
+        return;
+    };
+
+    let Some(build_dir) = profile_dir.join("build").canonicalize().ok() else {
+        println!("cargo:warning=Could not resolve Cargo build directory for WebView2 loader copy");
+        return;
+    };
+
+    let arch = std::env::var("CARGO_CFG_TARGET_ARCH").unwrap_or_else(|_| "x64".to_string());
+    let webview2_arch = match arch.as_str() {
+        "x86_64" => "x64",
+        "x86" => "x86",
+        "aarch64" => "arm64",
+        other => {
+            println!("cargo:warning=Unsupported target arch for WebView2 loader copy: {other}");
+            return;
+        }
+    };
+
+    let source = find_webview2_loader(&build_dir, webview2_arch);
+    let Some(source) = source else {
+        println!("cargo:warning=Could not find WebView2Loader.dll to copy");
+        return;
+    };
+
+    for destination_dir in [profile_dir.to_path_buf(), profile_dir.join("deps")] {
+        if let Err(error) = fs::create_dir_all(&destination_dir) {
+            println!(
+                "cargo:warning=Failed to create WebView2 loader destination {}: {error}",
+                destination_dir.display()
+            );
+            continue;
+        }
+
+        let destination = destination_dir.join("WebView2Loader.dll");
+        if let Err(error) = fs::copy(&source, &destination) {
+            println!(
+                "cargo:warning=Failed to copy WebView2Loader.dll to {}: {error}",
+                destination.display()
+            );
+        }
+    }
+}
+
+#[cfg(windows)]
+fn find_webview2_loader(build_dir: &std::path::Path, arch: &str) -> Option<std::path::PathBuf> {
+    let entries = std::fs::read_dir(build_dir).ok()?;
+    for entry in entries.flatten() {
+        let candidate = entry
+            .path()
+            .join("out")
+            .join(arch)
+            .join("WebView2Loader.dll");
+        if candidate.exists() {
+            return Some(candidate);
+        }
+    }
+    None
+}
+
 fn main() {
+    #[cfg(windows)]
+    copy_webview2_loader();
+
     tauri_build::build()
 }

--- a/src-tauri/src/browser_webview.rs
+++ b/src-tauri/src/browser_webview.rs
@@ -151,12 +151,12 @@ pub fn emit_browser_webview_state<R: Runtime>(window: &Window<R>, state: &Browse
 }
 
 pub fn navigation_availability<R: Runtime>(
-    webview: &Webview<R>,
+    _webview: &Webview<R>,
 ) -> Option<BrowserNavigationAvailability> {
     #[cfg(target_os = "macos")]
     {
         let (tx, rx) = std::sync::mpsc::channel();
-        if webview
+        if _webview
             .with_webview(move |platform_webview| unsafe {
                 let view: &objc2_web_kit::WKWebView = &*platform_webview.inner().cast();
                 let _ = tx.send(BrowserNavigationAvailability {

--- a/src-tauri/src/commands/log_commands.rs
+++ b/src-tauri/src/commands/log_commands.rs
@@ -1,0 +1,14 @@
+use tauri::Manager;
+
+use crate::commands::dto::AppError;
+
+#[tauri::command]
+pub fn get_log_dir(app: tauri::AppHandle) -> Result<String, AppError> {
+    let dir = app
+        .path()
+        .app_log_dir()
+        .map_err(|e| AppError::UserVisible {
+            message: format!("Failed to resolve log directory: {e}"),
+        })?;
+    Ok(dir.to_string_lossy().into_owned())
+}

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -4,6 +4,7 @@ pub mod browser_webview_commands;
 pub mod database_commands;
 pub mod dto;
 pub mod feed_commands;
+pub mod log_commands;
 pub mod opml_commands;
 pub mod preference_commands;
 pub mod share_commands;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -43,16 +43,59 @@ fn database_init_error_message(error: &DomainError, db_path: &std::path::Path) -
     }
 }
 
+#[cfg(not(debug_assertions))]
+fn cleanup_old_logs(log_dir: &std::path::Path, max_age_days: u64) {
+    use std::time::{Duration, SystemTime};
+
+    let cutoff = match SystemTime::now().checked_sub(Duration::from_secs(max_age_days * 86400)) {
+        Some(t) => t,
+        None => return,
+    };
+    let entries = match std::fs::read_dir(log_dir) {
+        Ok(e) => e,
+        Err(_) => return,
+    };
+    for entry in entries.flatten() {
+        if let Ok(meta) = entry.metadata() {
+            if let Ok(modified) = meta.modified() {
+                if modified < cutoff {
+                    let _ = std::fs::remove_file(entry.path());
+                }
+            }
+        }
+    }
+}
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
-    tracing_subscriber::fmt()
-        .with_env_filter(
-            tracing_subscriber::EnvFilter::try_from_default_env()
-                .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("warn")),
-        )
-        .init();
+    #[cfg(debug_assertions)]
+    {
+        tracing_subscriber::fmt()
+            .with_env_filter(
+                tracing_subscriber::EnvFilter::try_from_default_env()
+                    .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("warn")),
+            )
+            .init();
+    }
 
-    tauri::Builder::default()
+    let builder = tauri::Builder::default();
+
+    #[cfg(not(debug_assertions))]
+    let builder = builder.plugin(
+        tauri_plugin_log::Builder::new()
+            .target(tauri_plugin_log::Target::new(
+                tauri_plugin_log::TargetKind::LogDir {
+                    file_name: Some("app".into()),
+                },
+            ))
+            .max_file_size(5_000_000) // ~5 MB
+            .rotation_strategy(tauri_plugin_log::RotationStrategy::KeepAll)
+            .level(log::LevelFilter::Info)
+            .timezone_strategy(tauri_plugin_log::TimezoneStrategy::UseLocal)
+            .build(),
+    );
+
+    builder
         .plugin(tauri_plugin_clipboard_manager::init())
         .plugin(tauri_plugin_opener::init())
         .plugin(tauri_plugin_updater::Builder::new().build())
@@ -96,6 +139,14 @@ pub fn run() {
             // Start background periodic sync
             let state = app.state::<AppState>();
             service::sync_scheduler::start_sync_scheduler(&state.db, app.handle().clone());
+
+            // Clean up old log files (release only)
+            #[cfg(not(debug_assertions))]
+            {
+                if let Ok(log_dir) = app.path().app_log_dir() {
+                    cleanup_old_logs(&log_dir, 7);
+                }
+            }
 
             Ok(())
         })
@@ -156,6 +207,7 @@ pub fn run() {
             commands::updater_commands::restart_app,
             commands::database_commands::get_database_info,
             commands::database_commands::vacuum_database,
+            commands::log_commands::get_log_dir,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -56,10 +56,17 @@ fn cleanup_old_logs(log_dir: &std::path::Path, max_age_days: u64) {
         Err(_) => return,
     };
     for entry in entries.flatten() {
+        let path = entry.path();
+        if path.file_name().is_some_and(|name| name == "app.log") {
+            continue;
+        }
         if let Ok(meta) = entry.metadata() {
+            if !meta.is_file() {
+                continue;
+            }
             if let Ok(modified) = meta.modified() {
                 if modified < cutoff {
-                    let _ = std::fs::remove_file(entry.path());
+                    let _ = std::fs::remove_file(path);
                 }
             }
         }
@@ -89,7 +96,7 @@ pub fn run() {
                 },
             ))
             .max_file_size(5_000_000) // ~5 MB
-            .rotation_strategy(tauri_plugin_log::RotationStrategy::KeepAll)
+            .rotation_strategy(tauri_plugin_log::RotationStrategy::KeepOne)
             .level(log::LevelFilter::Info)
             .timezone_strategy(tauri_plugin_log::TimezoneStrategy::UseLocal)
             .build(),

--- a/src/api/tauri-commands.ts
+++ b/src/api/tauri-commands.ts
@@ -353,3 +353,6 @@ export const restartApp = () => safeInvoke("restart_app", { response: z.null() }
 export const getDatabaseInfo = () => safeInvoke("get_database_info", { response: DatabaseInfoDtoSchema });
 
 export const vacuumDatabase = () => safeInvoke("vacuum_database", { response: DatabaseInfoDtoSchema });
+
+// Logs
+export const getLogDir = () => safeInvoke("get_log_dir", { response: z.string() });

--- a/src/components/settings/data-settings.tsx
+++ b/src/components/settings/data-settings.tsx
@@ -1,7 +1,8 @@
 import { Result } from "@praha/byethrow";
+import { revealItemInDir } from "@tauri-apps/plugin-opener";
 import { useCallback, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { getDatabaseInfo, vacuumDatabase } from "@/api/tauri-commands";
+import { getDatabaseInfo, getLogDir, vacuumDatabase } from "@/api/tauri-commands";
 import { SectionHeading } from "@/components/settings/settings-components";
 import { Button } from "@/components/ui/button";
 import { useUiStore } from "@/stores/ui-store";
@@ -52,6 +53,24 @@ export function DataSettings() {
     setSettingsLoading(false);
   };
 
+  const openLogDir = async () => {
+    Result.pipe(
+      await getLogDir(),
+      Result.inspect(async (dir) => {
+        try {
+          await revealItemInDir(dir);
+        } catch (e) {
+          console.error("Failed to open log directory:", e);
+          showToast(t("data.open_log_dir_failed", { message: String(e) }));
+        }
+      }),
+      Result.inspectError((e) => {
+        console.error("Failed to get log directory:", e);
+        showToast(t("data.open_log_dir_failed", { message: e.message }));
+      }),
+    );
+  };
+
   return (
     <div className="p-6">
       <h2 className="mb-6 text-center text-lg font-semibold">{t("data.heading")}</h2>
@@ -67,6 +86,13 @@ export function DataSettings() {
         <p className="mb-3 text-xs text-muted-foreground">{t("data.vacuum_description")}</p>
         <Button variant="outline" size="sm" disabled={vacuuming} onClick={handleVacuum}>
           {vacuuming ? t("data.vacuuming") : t("data.vacuum")}
+        </Button>
+      </section>
+      <section className="mt-6">
+        <SectionHeading>{t("data.logs")}</SectionHeading>
+        <p className="mb-3 text-xs text-muted-foreground">{t("data.open_log_dir_description")}</p>
+        <Button variant="outline" size="sm" onClick={openLogDir}>
+          {t("data.open_log_dir")}
         </Button>
       </section>
     </div>

--- a/src/components/settings/data-settings.tsx
+++ b/src/components/settings/data-settings.tsx
@@ -1,5 +1,5 @@
 import { Result } from "@praha/byethrow";
-import { revealItemInDir } from "@tauri-apps/plugin-opener";
+import { openPath } from "@tauri-apps/plugin-opener";
 import { useCallback, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { getDatabaseInfo, getLogDir, vacuumDatabase } from "@/api/tauri-commands";
@@ -58,7 +58,7 @@ export function DataSettings() {
       await getLogDir(),
       Result.inspect(async (dir) => {
         try {
-          await revealItemInDir(dir);
+          await openPath(dir);
         } catch (e) {
           console.error("Failed to open log directory:", e);
           showToast(t("data.open_log_dir_failed", { message: String(e) }));

--- a/src/dev-mocks.ts
+++ b/src/dev-mocks.ts
@@ -469,6 +469,8 @@ export function setupDevMocks() {
         return { db_size_bytes: 2_500_000, wal_size_bytes: 150_000, total_size_bytes: 2_650_000 };
       case "vacuum_database":
         return { db_size_bytes: 2_100_000, wal_size_bytes: 0, total_size_bytes: 2_100_000 };
+      case "get_log_dir":
+        return "/tmp/mock-logs";
       case "check_for_update":
         return null;
       case "download_and_install_update":

--- a/src/locales/en/settings.json
+++ b/src/locales/en/settings.json
@@ -204,6 +204,10 @@
     "vacuum_description": "Reclaim unused space by optimizing the database.",
     "vacuuming": "Optimizing...",
     "vacuum_success": "Database optimized ({{saved}})",
-    "vacuum_failed": "Optimization failed: {{message}}"
+    "vacuum_failed": "Optimization failed: {{message}}",
+    "logs": "Logs",
+    "open_log_dir": "Open Log Directory",
+    "open_log_dir_description": "View application log files for troubleshooting.",
+    "open_log_dir_failed": "Failed to open log directory: {{message}}"
   }
 }

--- a/src/locales/ja/settings.json
+++ b/src/locales/ja/settings.json
@@ -204,6 +204,10 @@
     "vacuum_description": "データベースを最適化して未使用領域を回収します。",
     "vacuuming": "最適化中...",
     "vacuum_success": "データベースを最適化しました ({{saved}})",
-    "vacuum_failed": "最適化に失敗しました: {{message}}"
+    "vacuum_failed": "最適化に失敗しました: {{message}}",
+    "logs": "ログ",
+    "open_log_dir": "ログフォルダを開く",
+    "open_log_dir_description": "トラブルシューティング用のアプリケーションログファイルを確認します。",
+    "open_log_dir_failed": "ログフォルダを開けませんでした: {{message}}"
   }
 }


### PR DESCRIPTION
## Summary

Closes #20

- リリースビルドで `tauri-plugin-log` によるファイルログ出力を追加（dev は従来通り stdout）
- サイズベースローテーション（5MB）、7日超の古いログを起動時に自動削除
- `get_log_dir` Tauri コマンド + フロントエンド IPC ラッパー追加
- Data 設定画面に「ログフォルダを開く」ボタン追加（en/ja i18n 対応）
- `@tauri-apps/plugin-opener` npm パッケージ追加

## Test plan

- [x] TypeScript 型チェック通過
- [x] Biome lint 通過
- [x] Vitest 全330テスト合格
- [ ] `cargo check` / `cargo clippy` 通過（実機またはCIで確認が必要）
- [ ] リリースビルドでログファイルが出力されることを確認
- [ ] 「ログフォルダを開く」ボタンがネイティブアプリで動作することを確認

https://claude.ai/code/session_01WTFBMd1A9jLBoStJurMS6U