### PR TITLE
fix(reader): calm hover motion across subscriptions

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -127,6 +127,7 @@ Elevation scale:
 - Inputs and Forms: Inputs should stay neutral and legible, with warm borders and a restrained focus treatment. Prefer border emphasis or accent-orange focus hints over cold blue rings. Shared input-like primitives should use `rounded-md`; switches remain `rounded-full`. Loading bars are the exception: they may use the dedicated loading blue when the warm ring is not legible enough.
 - Settings Forms: Treat settings pages as desktop-app settings panels, not generic web forms. The canonical row is a stable left label column plus a stable right control column. Controls should resolve against one right-column endpoint so input, select, button, checkbox, switch, and segmented choice groups feel aligned as a system. Long controls may cap their width instead of stretching edge-to-edge, but compact controls must still live on the same control rail rather than floating at arbitrary intermediate positions. The desired rhythm is: section gap first, then heading-to-first-row gap, then a consistent row cadence, with a fixed label-to-control column gap.
 - Settings and Review Hierarchy: In settings and feed-cleanup style workspaces, the outer shell should read as framing, account/status subsections should sit one tonal step quieter than the active editing surface, and only the primary next action should get the strongest emphasis. Avoid letting navigation rows, passive summary cards, or repeated outline buttons compete with the main review action.
+- Dense Workspace Hover: In subscriptions, cleanup, settings, and other high-density workspace panels, hover feedback should stay geometrically stable. Prefer tone, border, text, and shadow changes over hover lift so repeated rows do not shimmer, feel nauseating, or clip against nearby edges.
 - Lists and Navigation: Lists should separate items through tone and dividers rather than heavy blocks of accent color. Navigation and tab treatments should feel clean, compact, and editorial rather than dashboard-like. Smart views, context strips, filter chips, and article state icons may use the fixed unread/starred semantic colors, but the color should usually appear as icon tint or a light surface wash rather than a solid block.
 - Media and Preview Surfaces: Code or browser previews may use darker surfaces, but they should still feel framed by warm borders and integrated into the cream-based system rather than floating as disconnected black panels.
 - Dialog and Popup Shells: Dialogs, command palettes, and other popup shells should use named scrim roles from the token layer instead of ad hoc alpha literals. Use the standard dialog scrim for modal separation and the readable scrim only when the content behind the popup needs to stay legible as a softened surface instead of falling into darkness.
@@ -165,6 +166,7 @@ Elevation scale:
 - Border and divider responsibility should live in one place. Avoid combining a section border, an inner scroll lane, and last-mile padding adjustments in a way that creates double lines or drifting endpoints.
 - Numeric badges, counters, and rapidly changing labels should avoid jitter. Reserve enough width, use tabular figures when repeated values update in place, and keep local state changes from changing surrounding alignment.
 - Motion and feedback should reinforce continuity. Prefer opacity, tone, border, and transform changes over height or position changes that cause reflow, especially in dense workspace panels and two-pane review layouts.
+- In dense workspace panels, avoid compound hover motion. Do not stack row lift, card lift, and icon scale on the same interaction unless a component is intentionally special and documented as such.
 
 ### Border Radius Scale
 
@@ -202,6 +204,7 @@ Surface governance:
 - Buttons shift text toward the tertiary accent (`#cf2d56`) on hover
 - Links may shift toward primary or add understated underline emphasis
 - Cards intensify shadow or border contrast subtly rather than jumping in scale
+- Dense workspace rows and summary cards should default to non-lifting hover treatments. If hover needs stronger emphasis, increase border or surface contrast before adding translate or scale.
 
 ### Focus States
 

--- a/src/__tests__/components/design-ui-primitives.test.tsx
+++ b/src/__tests__/components/design-ui-primitives.test.tsx
@@ -61,6 +61,7 @@ describe("Design-themed UI primitives", () => {
     expect(globalCss).toContain("--motion-ease-standard: cubic-bezier(0.22, 1, 0.36, 1);");
     expect(globalCss).toContain(".motion-disclosure-panel");
     expect(globalCss).toContain(".motion-contextual-surface");
+    expect(globalCss).toContain(".motion-static-hover-surface");
     expect(globalCss).toContain(".motion-content-swap");
     expect(globalCss).toContain(".motion-popup-surface");
     expect(globalCss).toContain(".motion-disclosure-trigger:hover");

--- a/src/__tests__/components/design-ui-primitives.test.tsx
+++ b/src/__tests__/components/design-ui-primitives.test.tsx
@@ -64,7 +64,10 @@ describe("Design-themed UI primitives", () => {
     expect(globalCss).toContain(".motion-content-swap");
     expect(globalCss).toContain(".motion-popup-surface");
     expect(globalCss).toContain(".motion-disclosure-trigger:hover");
-    expect(globalCss).toContain("transform: translateY(-1px);");
+    expect(globalCss).not.toContain("transform: translateY(-1px);");
+    expect(globalCss).toContain(
+      "box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--color-border-strong) 28%, transparent);",
+    );
     expect(globalCss).toContain(".motion-contextual-surface:focus-within");
     expect(globalCss).toContain('.motion-content-swap[data-motion-phase="entering"]');
     expect(globalCss).toContain("@keyframes motion-content-swap-enter");

--- a/src/__tests__/components/subscriptions-index-page.test.tsx
+++ b/src/__tests__/components/subscriptions-index-page.test.tsx
@@ -162,7 +162,7 @@ describe("SubscriptionsIndexPage", () => {
       "neutral",
     );
     expect(selectedFeed).toHaveAttribute("aria-pressed", "true");
-    expect(selectedFeed).toHaveClass("transition-[background-color,border-color,box-shadow,transform]");
+    expect(selectedFeed).toHaveClass("transition-[background-color,border-color,box-shadow]");
     expect(selectedFeed).toHaveClass("bg-[color:var(--subscriptions-list-row-selected-surface)]");
     expect(selectedFeed).toHaveClass("shadow-[var(--subscriptions-list-row-selected-shadow)]");
     expect(selectedFeed).toHaveClass("focus-visible:ring-2");

--- a/src/__tests__/components/subscriptions-index-page.test.tsx
+++ b/src/__tests__/components/subscriptions-index-page.test.tsx
@@ -162,7 +162,7 @@ describe("SubscriptionsIndexPage", () => {
       "neutral",
     );
     expect(selectedFeed).toHaveAttribute("aria-pressed", "true");
-    expect(selectedFeed).toHaveClass("transition-[background-color,border-color,box-shadow]");
+    expect(selectedFeed).toHaveClass("motion-static-hover-surface");
     expect(selectedFeed).toHaveClass("bg-[color:var(--subscriptions-list-row-selected-surface)]");
     expect(selectedFeed).toHaveClass("shadow-[var(--subscriptions-list-row-selected-shadow)]");
     expect(selectedFeed).toHaveClass("focus-visible:ring-2");

--- a/src/components/subscriptions-index/subscriptions-list-pane.tsx
+++ b/src/components/subscriptions-index/subscriptions-list-pane.tsx
@@ -135,7 +135,7 @@ export function SubscriptionsListPane({
                           aria-pressed={selectedFeedId === row.feed.id}
                           onClick={() => onSelectFeed(row.feed.id)}
                           className={cn(
-                            "items-center rounded-md border border-transparent px-3.5 py-3.5 shadow-none transition-[background-color,border-color,box-shadow,transform] duration-200 ease-[cubic-bezier(0.22,1,0.36,1)] hover:-translate-y-px motion-reduce:transition-none",
+                            "items-center rounded-md border border-transparent px-3.5 py-3.5 shadow-none transition-[background-color,border-color,box-shadow] duration-200 ease-[cubic-bezier(0.22,1,0.36,1)] motion-reduce:transition-none",
                             selectedFeedId === row.feed.id
                               ? "border-[color:var(--subscriptions-list-row-selected-border)] bg-[color:var(--subscriptions-list-row-selected-surface)] shadow-[var(--subscriptions-list-row-selected-shadow)]"
                               : "bg-background/15 hover:border-[color:var(--subscriptions-list-divider)] hover:bg-[color:var(--subscriptions-list-row-hover)]",

--- a/src/components/subscriptions-index/subscriptions-list-pane.tsx
+++ b/src/components/subscriptions-index/subscriptions-list-pane.tsx
@@ -135,7 +135,7 @@ export function SubscriptionsListPane({
                           aria-pressed={selectedFeedId === row.feed.id}
                           onClick={() => onSelectFeed(row.feed.id)}
                           className={cn(
-                            "items-center rounded-md border border-transparent px-3.5 py-3.5 shadow-none transition-[background-color,border-color,box-shadow] duration-200 ease-[cubic-bezier(0.22,1,0.36,1)] motion-reduce:transition-none",
+                            "motion-static-hover-surface items-center rounded-md border border-transparent px-3.5 py-3.5 shadow-none",
                             selectedFeedId === row.feed.id
                               ? "border-[color:var(--subscriptions-list-row-selected-border)] bg-[color:var(--subscriptions-list-row-selected-surface)] shadow-[var(--subscriptions-list-row-selected-shadow)]"
                               : "bg-background/15 hover:border-[color:var(--subscriptions-list-divider)] hover:bg-[color:var(--subscriptions-list-row-hover)]",
@@ -143,7 +143,7 @@ export function SubscriptionsListPane({
                           leading={
                             <span
                               className={cn(
-                                "inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-md border transition-[background-color,border-color,transform] duration-200 ease-[cubic-bezier(0.22,1,0.36,1)] group-hover:scale-[1.03] motion-reduce:transition-none",
+                                "inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-md border transition-[background-color,border-color] duration-200 ease-[cubic-bezier(0.22,1,0.36,1)] motion-reduce:transition-none",
                                 selectedFeedId === row.feed.id
                                   ? "bg-surface-1 text-foreground"
                                   : "bg-surface-2/88 text-foreground",

--- a/src/components/subscriptions-index/subscriptions-overview-summary.tsx
+++ b/src/components/subscriptions-index/subscriptions-overview-summary.tsx
@@ -124,7 +124,7 @@ export function SubscriptionsOverviewSummary({
           const isActionable = Number.isFinite(numericValue);
           const isPrimary = card.tone === "review";
           const className = cn(
-            "relative flex min-h-[96px] w-full min-w-0 flex-col justify-between overflow-hidden rounded-lg border px-3.5 py-3 text-left transition-[border-color,background-color,color,box-shadow] duration-150 sm:min-h-[108px] sm:px-4.5 sm:py-4",
+            "motion-static-hover-surface relative flex min-h-[96px] w-full min-w-0 flex-col justify-between overflow-hidden rounded-lg border px-3.5 py-3 text-left sm:min-h-[108px] sm:px-4.5 sm:py-4",
             resolveCardClassName(card.tone),
             isPrimary && "shadow-[var(--subscriptions-summary-card-shadow)]",
             isPrimary && "sm:col-span-2 lg:col-span-1",

--- a/src/components/subscriptions-index/subscriptions-overview-summary.tsx
+++ b/src/components/subscriptions-index/subscriptions-overview-summary.tsx
@@ -124,7 +124,7 @@ export function SubscriptionsOverviewSummary({
           const isActionable = Number.isFinite(numericValue);
           const isPrimary = card.tone === "review";
           const className = cn(
-            "relative flex min-h-[96px] w-full min-w-0 flex-col justify-between overflow-hidden rounded-lg border px-3.5 py-3 text-left transition-[border-color,background-color,color,box-shadow,transform] duration-150 sm:min-h-[108px] sm:px-4.5 sm:py-4",
+            "relative flex min-h-[96px] w-full min-w-0 flex-col justify-between overflow-hidden rounded-lg border px-3.5 py-3 text-left transition-[border-color,background-color,color,box-shadow] duration-150 sm:min-h-[108px] sm:px-4.5 sm:py-4",
             resolveCardClassName(card.tone),
             isPrimary && "shadow-[var(--subscriptions-summary-card-shadow)]",
             isPrimary && "sm:col-span-2 lg:col-span-1",
@@ -136,11 +136,7 @@ export function SubscriptionsOverviewSummary({
               <button
                 key={card.label}
                 type="button"
-                className={cn(
-                  className,
-                  "group cursor-pointer",
-                  "hover:-translate-y-0.5 hover:border-border-strong/90",
-                )}
+                className={cn(className, "group cursor-pointer", "hover:border-border-strong/90")}
                 aria-pressed={card.isActive}
                 onClick={() => onSelectFilter(card.filterKey)}
               >

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -681,6 +681,18 @@ body {
   transition-timing-function: var(--motion-ease-standard);
 }
 
+.motion-static-hover-surface {
+  transition-property: background-color, border-color, color, box-shadow, opacity;
+  transition-duration: var(--motion-duration-contextual);
+  transition-timing-function: var(--motion-ease-standard);
+}
+
+.motion-static-hover-surface:hover,
+.motion-static-hover-surface:active,
+.motion-static-hover-surface:focus-visible {
+  transform: none;
+}
+
 @keyframes motion-content-swap-enter {
   from {
     opacity: 0;
@@ -762,6 +774,7 @@ body {
   .motion-pressable-surface,
   .motion-button-surface,
   .motion-contextual-surface,
+  .motion-static-hover-surface,
   .motion-content-swap,
   .motion-popup-overlay,
   .motion-popup-dialog,

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -636,17 +636,13 @@ body {
 }
 
 .motion-disclosure-trigger {
-  transition-property: background-color, border-color, color, box-shadow, transform;
+  transition-property: background-color, border-color, color, box-shadow;
   transition-duration: var(--motion-duration-disclosure);
   transition-timing-function: var(--motion-ease-standard);
 }
 
 .motion-disclosure-trigger:hover {
-  transform: translateY(-1px);
-}
-
-.motion-disclosure-trigger:active {
-  transform: translateY(0);
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--color-border-strong) 28%, transparent);
 }
 
 .motion-disclosure-icon {


### PR DESCRIPTION
## 概要

購読一覧ワークスペースの hover モーションを落ち着かせ、ホバー時にボタンやカードが上へ浮いて見切れる挙動をなくします。

- disclosure trigger の hover を位置移動から inset 境界強調へ変更
- 購読一覧の行 hover から上方向 transform を削除
- 購読サマリーカード hover から上方向 transform を削除
- 関連テストを更新

## 種別

- [ ] 🚀 feature (新機能)
- [x] 🐛 fix (バグ修正)
- [ ] 📚 docs (ドキュメント)
- [ ] 🔧 chore (その他)
- [ ] 💥 breaking (破壊的変更)

## 影響範囲

- [x] フロントエンド (React / TypeScript)
- [ ] バックエンド (Rust / Tauri)
- [ ] データベース (SQLite / rusqlite)
- [ ] API連携 (FreshRSS / GReader)
- [ ] CI/CD
- [ ] ドキュメント

## 関連Issue

なし

## 確認済み

- [x] 動作確認完了
- [x] 品質チェック通過 (`mise run check`)
- [ ] 環境変数の変更時: `.env` を暗号化 (`dotenvx encrypt`)

---
