### PR TITLE
[codex] Update GitHub Actions versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,9 +28,9 @@ jobs:
     timeout-minutes: 10
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v6.0.2
 
-      - uses: jdx/mise-action@v4
+      - uses: jdx/mise-action@v4.0.1
 
       - uses: dtolnay/rust-toolchain@stable
         with:
@@ -50,7 +50,7 @@ jobs:
         os: [ubuntu-latest, windows-latest]
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v6.0.2
 
       - name: Install Tauri system dependencies
         if: matrix.os == 'ubuntu-latest'
@@ -58,13 +58,13 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y ${{ env.TAURI_SYSTEM_DEPS }}
 
-      - uses: jdx/mise-action@v4
+      - uses: jdx/mise-action@v4.0.1
 
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@v2.9.1
         with:
           workspaces: src-tauri
 
@@ -82,7 +82,7 @@ jobs:
         os: [ubuntu-latest, windows-latest]
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v6.0.2
 
       - name: Install Tauri system dependencies
         if: matrix.os == 'ubuntu-latest'
@@ -90,11 +90,11 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y ${{ env.TAURI_SYSTEM_DEPS }}
 
-      - uses: jdx/mise-action@v4
+      - uses: jdx/mise-action@v4.0.1
 
       - uses: dtolnay/rust-toolchain@stable
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@v2.9.1
         with:
           workspaces: src-tauri
 
@@ -112,9 +112,9 @@ jobs:
         os: [ubuntu-latest, windows-latest]
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v6.0.2
 
-      - uses: jdx/mise-action@v4
+      - uses: jdx/mise-action@v4.0.1
 
       - run: pnpm install --frozen-lockfile
 
@@ -130,13 +130,13 @@ jobs:
         os: [macos-latest, windows-latest]
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v6.0.2
 
-      - uses: jdx/mise-action@v4
+      - uses: jdx/mise-action@v4.0.1
 
       - uses: dtolnay/rust-toolchain@stable
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@v2.9.1
         with:
           workspaces: src-tauri
 

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -13,6 +13,6 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/labeler@v5
+      - uses: actions/labeler@v6.0.1
         with:
           configuration-path: .github/labeler.yml

--- a/.github/workflows/pr-insights-labeler.yml
+++ b/.github/workflows/pr-insights-labeler.yml
@@ -16,12 +16,12 @@ jobs:
     timeout-minutes: 5
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v6.0.2
         with:
           fetch-depth: 0
 
       - name: Apply PR Insights Labels
-        uses: jey3dayo/pr-insights-labeler@v1
+        uses: jey3dayo/pr-insights-labeler@v1.11.1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,22 +28,34 @@ jobs:
     timeout-minutes: 30
 
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@v6.0.2
 
-      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4
+      - uses: jdx/mise-action@v4.0.1
 
-      - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # stable
+      - name: Resolve pnpm store path
+        id: pnpm-store
+        shell: bash
+        run: echo "path=$(pnpm store path --silent)" >> "$GITHUB_OUTPUT"
+
+      - uses: actions/cache@v5.0.5
+        with:
+          path: ${{ steps.pnpm-store.outputs.path }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
+
+      - uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: stable
           targets: ${{ runner.os == 'macOS' && 'aarch64-apple-darwin' || '' }}
 
-      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2
+      - uses: Swatinem/rust-cache@v2.9.1
         with:
           workspaces: src-tauri
 
       - run: pnpm install --frozen-lockfile
 
-      - uses: tauri-apps/tauri-action@84b9d35b5fc46c1e45415bdb6144030364f7ebc5 # v0
+      - uses: tauri-apps/tauri-action@v0.6.2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
@@ -54,4 +66,4 @@ jobs:
           releaseDraft: true
           generateReleaseNotes: false
           prerelease: false
-          args: ${{ matrix.args }} --config src-tauri/tauri.release.conf.json
+          args: ${{ matrix.args }} --config src-tauri/tauri.release.conf.json --ci


### PR DESCRIPTION
## Summary
- Update GitHub Actions references to explicit latest stable version tags
- Keep the release workflow pnpm store cache and Tauri --ci release args

## Validation
- mise run lint:yaml
- mise run lint:actions
- mise run ci
- git diff --check
