### PR TITLE
fix(ci): repair macos rustup bootstrap

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -413,6 +413,20 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
 
+      - name: Repair macOS Rustup bootstrap
+        if: runner.os == 'macOS'
+        shell: bash
+        run: |
+          set -euo pipefail
+          cargo_version="$(cargo --version 2>&1 || true)"
+          if [[ "$cargo_version" == rustup-init* ]]; then
+            rustup_init="$(command -v rustup-init || command -v cargo)"
+            "$rustup_init" -y --default-toolchain stable --profile minimal
+            echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
+          fi
+          cargo --version
+          rustc --version
+
       - uses: Swatinem/rust-cache@23869a5bd66c73db3c0ac40331f3206eb23791dc
         with:
           workspaces: src-tauri


### PR DESCRIPTION
## 概要

macOS native smoke で cargo が rustup-init のまま解決され、Tauri build の cargo metadata が失敗するケースを検出して Rustup を再初期化します。

## 種別

- [ ] 🚀 feature (新機能)
- [x] 🐛 fix (バグ修正)
- [ ] 📚 docs (ドキュメント)
- [ ] 🔧 chore (その他)
- [ ] 💥 breaking (破壊的変更)

## 影響範囲

- [ ] フロントエンド (React / TypeScript)
- [ ] バックエンド (Rust / Tauri)
- [ ] データベース (SQLite / rusqlite)
- [ ] API連携 (FreshRSS / GReader)
- [x] CI/CD
- [ ] ドキュメント

## 関連Issue


## 確認済み

DOM/CI/focused test は `mise run test:unit:dom` / `mise run ci` / focused test の確認を指します。

- [ ] 動作確認完了
- [x] 型エラー 0 件 (`mise run check` の `lint:types`)
- [x] リント違反 0 件 (`mise run check` の `lint`)
- [x] 高速テスト成功 (`mise run check` の `test:unit:fast` / `test:rust`)
- [x] フォーマッター適用済み (`mise run check` の `format`)
- [x] jsdom / DOM / React rendering / PR handoff / release / native / Storybook 影響時: `mise run check`, `mise run lint:actions-shell`, `mise run format:check`
- [ ] 環境変数の変更時: `.env` を暗号化 (`dotenvx encrypt`)

---

<!-- レビューボットの自動生成コメントはここに挿入されます -->