### PR TITLE
refactor(reader): lazy load browser view

### DIFF
--- a/src/__tests__/components/article-list.test.tsx
+++ b/src/__tests__/components/article-list.test.tsx
@@ -624,7 +624,7 @@ describe("ArticleList", () => {
       expect(useUiStore.getState().contentMode).toBe("browser");
     });
 
-    const host = screen.getByTestId("browser-webview-host");
+    const host = await screen.findByTestId("browser-webview-host");
     host.setAttribute("tabindex", "-1");
     host.focus();
     expect(host).toHaveFocus();
@@ -1637,7 +1637,7 @@ describe("ArticleList", () => {
       expect(useUiStore.getState().contentMode).toBe("browser");
     });
 
-    const host = screen.getByTestId("browser-webview-host");
+    const host = await screen.findByTestId("browser-webview-host");
     host.setAttribute("tabindex", "-1");
     host.focus();
     expect(host).toHaveFocus();

--- a/src/__tests__/components/article-view-state.test.tsx
+++ b/src/__tests__/components/article-view-state.test.tsx
@@ -1,6 +1,14 @@
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const browserViewMock = vi.hoisted(() =>
+  vi.fn(({ labels, onCloseOverlay }: { labels: { closeWebPreview: string }; onCloseOverlay: () => void }) => (
+    <button type="button" aria-label={labels.closeWebPreview} onClick={onCloseOverlay}>
+      Web Preview
+    </button>
+  )),
+);
 
 vi.mock("react-i18next", () => ({
   useTranslation: () => ({
@@ -9,11 +17,7 @@ vi.mock("react-i18next", () => ({
 }));
 
 vi.mock("@/components/reader/browser-view", () => ({
-  BrowserView: ({ labels, onCloseOverlay }: { labels: { closeWebPreview: string }; onCloseOverlay: () => void }) => (
-    <button type="button" aria-label={labels.closeWebPreview} onClick={onCloseOverlay}>
-      Web Preview
-    </button>
-  ),
+  BrowserView: browserViewMock,
 }));
 
 import {
@@ -23,6 +27,10 @@ import {
 } from "@/components/reader/article-view-state";
 
 describe("BrowserOverlaySurface", () => {
+  beforeEach(() => {
+    browserViewMock.mockClear();
+  });
+
   it("keeps reader children visible without mounting the browser view when hidden", () => {
     render(
       <BrowserOverlaySurface showBrowserView={false} onCloseOverlay={vi.fn()}>
@@ -32,6 +40,7 @@ describe("BrowserOverlaySurface", () => {
 
     expect(screen.getByText("Reader body")).toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "Close Web Preview" })).not.toBeInTheDocument();
+    expect(browserViewMock).not.toHaveBeenCalled();
   });
 
   it("mounts Web Preview with the reader close language and passes the close handler", async () => {
@@ -40,7 +49,7 @@ describe("BrowserOverlaySurface", () => {
 
     render(<BrowserOverlaySurface onCloseOverlay={onCloseOverlay} />);
 
-    await user.click(screen.getByRole("button", { name: "Close Web Preview" }));
+    await user.click(await screen.findByRole("button", { name: "Close Web Preview" }));
 
     expect(onCloseOverlay).toHaveBeenCalledTimes(1);
   });

--- a/src/__tests__/components/article-view.test.tsx
+++ b/src/__tests__/components/article-view.test.tsx
@@ -611,7 +611,9 @@ describe("ArticleView", () => {
     });
 
     fireEvent.click(
-      await within(screen.getByTestId("browser-overlay-chrome")).findByRole("button", { name: "Close Web Preview" }),
+      await within(await screen.findByTestId("browser-overlay-chrome")).findByRole("button", {
+        name: "Close Web Preview",
+      }),
     );
 
     await waitFor(() => {
@@ -667,7 +669,9 @@ describe("ArticleView", () => {
     });
 
     fireEvent.click(
-      await within(screen.getByTestId("browser-overlay-chrome")).findByRole("button", { name: "Close Web Preview" }),
+      await within(await screen.findByTestId("browser-overlay-chrome")).findByRole("button", {
+        name: "Close Web Preview",
+      }),
     );
 
     await waitFor(() => {
@@ -717,20 +721,21 @@ describe("ArticleView", () => {
       expect(useUiStore.getState().contentMode).toBe("browser");
     });
 
-    const overlayActions = screen.getByTestId("browser-overlay-actions");
+    const overlayActions = await screen.findByTestId("browser-overlay-actions");
+    const overlayChrome = await screen.findByTestId("browser-overlay-chrome");
 
     expect(
-      within(screen.getByTestId("browser-overlay-chrome")).getByRole("button", {
+      within(overlayChrome).getByRole("button", {
         name: "Close Web Preview",
       }),
     ).toBeInTheDocument();
     expect(
-      within(screen.getByTestId("browser-overlay-chrome")).getByRole("button", {
+      within(overlayChrome).getByRole("button", {
         name: "Back to Reader",
       }),
     ).toBeInTheDocument();
     expect(
-      within(screen.getByTestId("browser-overlay-chrome")).getByRole("button", {
+      within(overlayChrome).getByRole("button", {
         name: "Web forward",
       }),
     ).toBeInTheDocument();
@@ -791,7 +796,7 @@ describe("ArticleView", () => {
       expect(useUiStore.getState().contentMode).toBe("browser");
     });
 
-    const overlayActions = screen.getByTestId("browser-overlay-actions");
+    const overlayActions = await screen.findByTestId("browser-overlay-actions");
     const customActionShells = within(overlayActions)
       .getAllByRole("button")
       .filter((button) =>
@@ -854,7 +859,9 @@ describe("ArticleView", () => {
     });
 
     fireEvent.click(
-      await within(screen.getByTestId("browser-overlay-chrome")).findByRole("button", { name: "Close Web Preview" }),
+      await within(await screen.findByTestId("browser-overlay-chrome")).findByRole("button", {
+        name: "Close Web Preview",
+      }),
     );
 
     await waitFor(() => {
@@ -914,7 +921,7 @@ describe("ArticleView", () => {
       expect(useUiStore.getState().browserUrl).toBe("https://example.com/1");
     });
 
-    const closeOverlayButton = await within(screen.getByTestId("browser-overlay-chrome")).findByRole("button", {
+    const closeOverlayButton = await within(await screen.findByTestId("browser-overlay-chrome")).findByRole("button", {
       name: "Close Web Preview",
     });
     closeOverlayButton.focus();
@@ -973,7 +980,7 @@ describe("ArticleView", () => {
       expect(useUiStore.getState().contentMode).toBe("browser");
     });
 
-    const host = screen.getByTestId("browser-webview-host");
+    const host = await screen.findByTestId("browser-webview-host");
     host.setAttribute("tabindex", "-1");
     host.focus();
     expect(host).toHaveFocus();
@@ -1165,7 +1172,7 @@ describe("ArticleView", () => {
       args: { url: "https://example.com/1", background: false },
     });
 
-    await user.click(within(screen.getByTestId("browser-overlay-chrome")).getAllByRole("button")[0]);
+    await user.click(within(await screen.findByTestId("browser-overlay-chrome")).getAllByRole("button")[0]);
 
     await waitFor(() => {
       expect(useUiStore.getState().contentMode).toBe("reader");
@@ -2304,7 +2311,7 @@ describe("ArticleView", () => {
       expect(useUiStore.getState().browserUrl).toBe("https://example.com/1");
     });
 
-    expect(screen.getByTestId("browser-overlay-shell")).toBeInTheDocument();
+    expect(await screen.findByTestId("browser-overlay-shell")).toBeInTheDocument();
     expect(screen.queryByText("Web Preview")).not.toBeInTheDocument();
 
     articleEntry.unmount();
@@ -2317,7 +2324,7 @@ describe("ArticleView", () => {
 
     render(<ArticleView />, { wrapper: createWrapper() });
 
-    expect(screen.getByTestId("browser-overlay-shell")).toBeInTheDocument();
+    expect(await screen.findByTestId("browser-overlay-shell")).toBeInTheDocument();
     expect(screen.queryByText("Web Preview")).not.toBeInTheDocument();
   });
 

--- a/src/components/reader/article-view-state.tsx
+++ b/src/components/reader/article-view-state.tsx
@@ -1,4 +1,4 @@
-import { lazy, Suspense, type ReactNode } from "react";
+import { lazy, type ReactNode, Suspense } from "react";
 import { useTranslation } from "react-i18next";
 import type { UiDisplayState } from "@/lib/ui/display-state.types";
 import type { BrowserOverlayCloseHandler, BrowserOverlayToolbarAction } from "./browser-view.types";

--- a/src/components/reader/article-view-state.tsx
+++ b/src/components/reader/article-view-state.tsx
@@ -1,8 +1,12 @@
-import type { ReactNode } from "react";
+import { lazy, Suspense, type ReactNode } from "react";
 import { useTranslation } from "react-i18next";
 import type { UiDisplayState } from "@/lib/ui/display-state.types";
-import { BrowserView } from "./browser-view";
 import type { BrowserOverlayCloseHandler, BrowserOverlayToolbarAction } from "./browser-view.types";
+
+const LazyBrowserView = lazy(async () => {
+  const mod = await import("./browser-view");
+  return { default: mod.BrowserView };
+});
 
 type BrowserOverlaySurfaceProps = {
   children?: ReactNode;
@@ -32,14 +36,16 @@ export function BrowserOverlaySurface({
     <div className="relative flex min-h-0 flex-1 flex-col">
       {children}
       {showBrowserView ? (
-        <BrowserView
-          scope="main-stage"
-          onCloseOverlay={onCloseOverlay}
-          labels={{
-            closeWebPreview: t("close_browser_overlay"),
-          }}
-          toolbarActions={toolbarActions}
-        />
+        <Suspense fallback={null}>
+          <LazyBrowserView
+            scope="main-stage"
+            onCloseOverlay={onCloseOverlay}
+            labels={{
+              closeWebPreview: t("close_browser_overlay"),
+            }}
+            toolbarActions={toolbarActions}
+          />
+        </Suspense>
       ) : null}
     </div>
   );


### PR DESCRIPTION
## 概要

Reader 初期表示から BrowserView を外すため、BrowserView を React.lazy + Suspense で遅延ロードします。

## 種別

- [ ] 🚀 feature (新機能)
- [ ] 🐛 fix (バグ修正)
- [ ] 📚 docs (ドキュメント)
- [x] 🔧 chore (その他)
- [ ] 💥 breaking (破壊的変更)

## 影響範囲

- [x] フロントエンド (React / TypeScript)
- [ ] バックエンド (Rust / Tauri)
- [ ] データベース (SQLite / rusqlite)
- [ ] API連携 (FreshRSS / GReader)
- [ ] CI/CD
- [ ] ドキュメント

## 関連Issue

なし

## 確認済み

DOM/CI/focused test は `mise run test:unit:dom` / `mise run ci` / focused test の確認を指します。

- [x] 動作確認完了
- [ ] 型エラー 0 件 (`mise run check` の `lint:types`)
- [ ] リント違反 0 件 (`mise run check` の `lint`)
- [ ] 高速テスト成功 (`mise run check` の `test:unit:fast` / `test:rust`)
- [x] フォーマッター適用済み (`mise run check` の `format`)
- [x] jsdom / DOM / React rendering / PR handoff / release / native / Storybook 影響時: DOM/CI/focused test を記録
- [ ] 環境変数の変更時: `.env` を暗号化 (`dotenvx encrypt`)

確認ログ:
- `MISE_TRUSTED_CONFIG_PATHS=$PWD pnpm exec vitest run src/__tests__/components/article-view-state.test.tsx src/__tests__/components/browser-view.test.tsx --project jsdom`
- `MISE_TRUSTED_CONFIG_PATHS=$PWD pnpm build`
- devApp: `VITE_DEV_WEB_URL=https://example.com mise run app:dev:web-preview` で Example Domain 表示まで確認。Computer Use は dev process を直接掴めず close handler は実機未完検証。

---

<!-- レビューボットの自動生成コメントはここに挿入されます -->