### PR TITLE
Make article filter toggles ghost style

### DIFF
--- a/src/__tests__/components/article-filter-toggle-button.node.test.ts
+++ b/src/__tests__/components/article-filter-toggle-button.node.test.ts
@@ -14,7 +14,10 @@ describe("ArticleFilterToggleButton class contracts", () => {
     expect(className).toContain("text-[13px]");
     expect(className).toContain("data-[pressed]:bg-surface-4");
     expect(className).toContain("data-[pressed]:text-foreground");
-    expect(className).toContain("data-[pressed]:shadow-[var(--control-chip-pressed-shadow)]");
+    expect(className).toContain("border-0");
+    expect(className).toContain("bg-transparent");
+    expect(className).toContain("shadow-none");
+    expect(className).not.toContain("data-[pressed]:shadow-[var(--control-chip-pressed-shadow)]");
     expect(className).not.toContain("semantic-tone-unread");
     expect(className).not.toContain("semantic-tone-starred");
   });

--- a/src/components/shared/article-filter-toggle-button.styles.ts
+++ b/src/components/shared/article-filter-toggle-button.styles.ts
@@ -7,10 +7,10 @@ export type ArticleFilterToggleSize = "compact" | "filter" | "comfortable";
 
 const ARTICLE_FILTER_TONE_CLASSNAMES: Record<ArticleFilterToggleMode, string> = {
   unread:
-    "text-foreground-soft hover:text-[var(--semantic-tone-unread-content-foreground)] data-[pressed]:bg-[var(--semantic-tone-unread-surface)] data-[pressed]:text-[var(--semantic-tone-unread-content-foreground)]",
-  all: "text-foreground-soft hover:text-foreground data-[pressed]:bg-surface-4 data-[pressed]:text-foreground data-[pressed]:shadow-[var(--control-chip-pressed-shadow)]",
+    "text-foreground-soft hover:bg-[var(--semantic-tone-unread-surface)] hover:text-[var(--semantic-tone-unread-content-foreground)] data-[pressed]:bg-[var(--semantic-tone-unread-surface)] data-[pressed]:text-[var(--semantic-tone-unread-content-foreground)]",
+  all: "text-foreground-soft hover:bg-surface-3/60 hover:text-foreground data-[pressed]:bg-surface-4 data-[pressed]:text-foreground",
   starred:
-    "text-foreground-soft hover:text-[var(--semantic-tone-starred-content-foreground)] data-[pressed]:bg-[var(--semantic-tone-starred-surface)] data-[pressed]:text-[var(--semantic-tone-starred-content-foreground)]",
+    "text-foreground-soft hover:bg-[var(--semantic-tone-starred-surface)] hover:text-[var(--semantic-tone-starred-content-foreground)] data-[pressed]:bg-[var(--semantic-tone-starred-surface)] data-[pressed]:text-[var(--semantic-tone-starred-content-foreground)]",
 };
 
 export function articleFilterToggleButtonClassName({
@@ -24,7 +24,7 @@ export function articleFilterToggleButtonClassName({
 }) {
   return cn(
     controlChipVariants({ size, interaction: "toggle" }),
-    "motion-interactive-surface motion-contextual-surface rounded-md select-none",
+    "motion-interactive-surface motion-contextual-surface rounded-md border-0 bg-transparent shadow-none select-none",
     className,
     ARTICLE_FILTER_TONE_CLASSNAMES[mode],
   );

--- a/src/components/storybook/ui-reference-control-specimens.tsx
+++ b/src/components/storybook/ui-reference-control-specimens.tsx
@@ -367,7 +367,7 @@ export function ArticleFilterToggleButtonSpecimen() {
       <div data-testid="reference-article-filter-toggle-buttons" className="grid gap-3 lg:grid-cols-2">
         <div className="rounded-md border border-border/60 bg-surface-1/70 p-3">
           <div className="mb-2 text-[11px] font-medium tracking-[0.14em] text-foreground-soft uppercase">
-            Colored state filters
+            Ghost state filters
           </div>
           <div className="flex flex-wrap items-center gap-2">
             <ArticleFilterToggleButton mode="unread" pressed value="unread" aria-label="Unread">


### PR DESCRIPTION
### Motivation
- Address visual floating outlines on the Unread / All / Starred filter buttons by switching to a ghost-style baseline so resting chrome is transparent and less visually heavy. 
- Align the filter toggles with the design system guidance to express state through subtle fills and tokenized semantic pressed states rather than persistent borders/shadows.

### Description
- Changed the article filter toggle baseline in `src/components/shared/article-filter-toggle-button.styles.ts` to remove persistent shadow/border and set a transparent resting chrome while adding quiet hover surface fills per semantic mode. 
- Updated the class-contract test in `src/__tests__/components/article-filter-toggle-button.node.test.ts` to assert the new ghost baseline (`border-0`, `bg-transparent`, `shadow-none`) and to keep semantic pressed-state token expectations. 
- Renamed the Storybook specimen label in `src/components/storybook/ui-reference-control-specimens.tsx` from "Colored state filters" to "Ghost state filters" to reflect the new visual treatment.

### Testing
- Ran the focused Node `vitest` suite for the related node tests with `vitest --project node` for `article-filter-toggle-button.node.test.ts` and the run succeeded. 
- Ran the jsdom `vitest` suite for `article-filter-toggle-button.test.ts` and `design-shared-components.test.tsx` and those tests succeeded. 
- Ran `biome check` on the modified files and it completed with no fixes required. 
- Attempted the full `mise run check` gate but it failed in this environment due to host toolchain issues (Node resolution using v20.20.2 caused a missing `node:sqlite` builtin and `rustfmt`/libdbus build prerequisites), so the repository-wide gate could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a3bb4e86fc4832f9d292b787494214f)