### PR TITLE
Refine feed detail panel density

### DIFF
--- a/src/__tests__/components/feed-detail-panel.test.tsx
+++ b/src/__tests__/components/feed-detail-panel.test.tsx
@@ -46,42 +46,81 @@ describe("FeedDetailPanel", () => {
       "border",
       "bg-surface-1/88",
     );
-    expect(screen.getByTestId("feed-detail-secondary-column").contains(screen.getByTestId("feed-detail-status"))).toBe(
-      true,
+    expect(
+      screen
+        .getByTestId("feed-detail-secondary-column")
+        .contains(screen.getByTestId("feed-detail-status")),
+    ).toBe(true);
+    expect(
+      screen
+        .getByTestId("feed-detail-secondary-column")
+        .contains(screen.getByTestId("feed-detail-reason-box")),
+    ).toBe(true);
+    expect(screen.getByTestId("feed-detail-secondary-column")).not.toHaveClass(
+      "grid-cols-[auto_minmax(0,1fr)]",
+    );
+    expect(screen.getByTestId("feed-detail-status")).toHaveClass(
+      "rounded-md",
+      "self-start",
     );
     expect(
-      screen.getByTestId("feed-detail-secondary-column").contains(screen.getByTestId("feed-detail-reason-box")),
-    ).toBe(true);
-    expect(screen.getByTestId("feed-detail-secondary-column")).not.toHaveClass("grid-cols-[auto_minmax(0,1fr)]");
-    expect(screen.getByTestId("feed-detail-status")).toHaveClass("rounded-md", "self-start");
-    expect(screen.getByTestId("feed-detail-reason-box").closest('[data-surface-card="section"]')).toHaveClass(
-      "bg-card/38",
-    );
-    expect(screen.getByText("静かな購読です。").closest('[data-surface-card="info"]')).toHaveClass("bg-surface-1/76");
+      screen
+        .getByTestId("feed-detail-reason-box")
+        .closest('[data-surface-card="section"]'),
+    ).toHaveClass("bg-card/38");
+    expect(
+      screen
+        .getByText("静かな購読です。")
+        .closest('[data-surface-card="info"]'),
+    ).toHaveClass("bg-surface-1/76");
     expect(screen.getByTestId("feed-detail-reason-box")).toHaveClass(
       "border-state-warning-border/80",
       "bg-state-warning-surface/80",
       "text-state-warning-foreground",
     );
-    expect(screen.getByText("静かな購読です。")).toHaveClass("text-foreground-soft");
+    expect(screen.getByText("静かな購読です。")).toHaveClass(
+      "text-foreground-soft",
+    );
     expect(screen.getByText("2026/04/17")).toHaveClass("text-foreground-soft");
     expect(screen.getByText("整理の判断材料")).toHaveClass("text-current");
-    expect(screen.getByText("未読 0件 / スター 0件")).toHaveClass("text-current");
-    expect(screen.getByText("フォルダ").closest("dt")).toHaveClass("text-foreground-soft");
-    expect(screen.getByText("Work").closest("dd")).toHaveClass("text-foreground");
-    expect(screen.getByRole("link", { name: "Help" })).toHaveAttribute("href", "https://example.com/help");
-    expect(screen.getByRole("link", { name: "Help" })).toHaveClass("text-foreground-soft");
-    expect(screen.getByTestId("feed-detail-recent-articles")).toHaveClass("space-y-2", "border-t", "pt-3");
-    expect(screen.getByText("最近の記事タイトル")).toHaveClass("text-[0.88rem]", "leading-5");
-    expect(screen.getByRole("button", { name: "フィードを編集" }).parentElement).toHaveClass("border-t", "pt-4");
-    expect(screen.getByRole("button", { name: "フィードを編集" })).toHaveClass(
-      "min-h-11",
-      "px-3",
-      "sm:px-3.5",
-      "border-border-strong",
-      "bg-surface-1/88",
+    expect(screen.getByText("未読 0件 / スター 0件")).toHaveClass(
+      "text-current",
     );
-    expect(screen.getByRole("button", { name: "フィードを編集" })).not.toHaveClass("rounded-full");
+    expect(screen.getByText("フォルダ").closest("dt")).toHaveClass(
+      "text-foreground-soft",
+    );
+    expect(screen.getByText("Work").closest("dd")).toHaveClass(
+      "text-foreground",
+    );
+    expect(screen.getByRole("link", { name: "Help" })).toHaveAttribute(
+      "href",
+      "https://example.com/help",
+    );
+    expect(screen.getByRole("link", { name: "Help" })).toHaveClass(
+      "text-foreground-soft",
+    );
+    expect(screen.getByTestId("feed-detail-recent-articles")).toHaveClass(
+      "space-y-2",
+      "border-t",
+      "pt-3",
+    );
+    expect(screen.getByText("最近の記事タイトル")).toHaveClass(
+      "text-[0.88rem]",
+      "leading-5",
+    );
+    expect(
+      screen.getByRole("button", { name: "フィードを編集" }).parentElement,
+    ).toHaveClass("border-t", "pt-3");
+    expect(screen.getByRole("button", { name: "フィードを編集" })).toHaveClass(
+      "min-h-9",
+      "w-auto",
+      "px-3",
+      "border-border/70",
+      "bg-surface-1/72",
+    );
+    expect(
+      screen.getByRole("button", { name: "フィードを編集" }),
+    ).not.toHaveClass("rounded-full");
   });
 
   it("renders neutral reason chips instead of muted chips", () => {
@@ -96,10 +135,20 @@ describe("FeedDetailPanel", () => {
       />,
     );
 
-    expect(screen.getByText("整理候補").closest("span")).toHaveAttribute("data-label-chip", "neutral");
-    expect(screen.getByText("整理候補").closest("span")).toHaveClass("bg-surface-1/80");
-    expect(screen.getByText("整理候補").closest("span")).toHaveClass("rounded-md");
-    expect(screen.getByText("未読 0件").closest("span")).toHaveAttribute("data-label-chip", "neutral");
+    expect(screen.getByText("整理候補").closest("span")).toHaveAttribute(
+      "data-label-chip",
+      "neutral",
+    );
+    expect(screen.getByText("整理候補").closest("span")).toHaveClass(
+      "bg-surface-1/80",
+    );
+    expect(screen.getByText("整理候補").closest("span")).toHaveClass(
+      "rounded-md",
+    );
+    expect(screen.getByText("未読 0件").closest("span")).toHaveAttribute(
+      "data-label-chip",
+      "neutral",
+    );
   });
 
   it("uses the feed detail link label as the displayed link text", () => {
@@ -113,8 +162,13 @@ describe("FeedDetailPanel", () => {
       />,
     );
 
-    expect(screen.getByRole("link", { name: "公式サイト" })).toHaveAttribute("href", "https://example.com/rss.xml");
-    expect(screen.queryByText("https://example.com/rss.xml")).not.toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "公式サイト" })).toHaveAttribute(
+      "href",
+      "https://example.com/rss.xml",
+    );
+    expect(
+      screen.queryByText("https://example.com/rss.xml"),
+    ).not.toBeInTheDocument();
   });
 
   it("keeps secondary actions on the shared touch target contract", () => {
@@ -128,7 +182,10 @@ describe("FeedDetailPanel", () => {
       />,
     );
 
-    expect(screen.getByRole("button", { name: "後で確認" })).toHaveClass("min-h-11", "px-4");
+    expect(screen.getByRole("button", { name: "後で確認" })).toHaveClass(
+      "min-h-11",
+      "px-4",
+    );
   });
 
   it("does not render invalid feed website title hrefs as links", () => {
@@ -142,9 +199,15 @@ describe("FeedDetailPanel", () => {
       />,
     );
 
-    expect(screen.getByRole("heading", { level: 3, name: "Private Feed" })).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { level: 3, name: "Private Feed" }),
+    ).toBeInTheDocument();
     expect(screen.queryByRole("link", { name: /Private Feed/ })).toBeNull();
-    expect(screen.queryByText("https://user:secret@example.com/private.xml?token=hidden")).toBeNull();
+    expect(
+      screen.queryByText(
+        "https://user:secret@example.com/private.xml?token=hidden",
+      ),
+    ).toBeNull();
   });
 
   it("allows reader shells to share the detail panel surface treatment", () => {
@@ -159,7 +222,9 @@ describe("FeedDetailPanel", () => {
     );
 
     expect(
-      screen.getByRole("heading", { level: 3, name: "Example Feed" }).closest('[data-surface-card="section"]'),
+      screen
+        .getByRole("heading", { level: 3, name: "Example Feed" })
+        .closest('[data-surface-card="section"]'),
     ).toHaveClass("rounded-3xl", "bg-card/38");
   });
 });

--- a/src/components/shared/feed-detail-card.tsx
+++ b/src/components/shared/feed-detail-card.tsx
@@ -29,9 +29,9 @@ export function FeedDetailCard({ children, className, style }: FeedDetailCardPro
 
 export function FeedDetailRow({ label, value }: FeedDetailRowProps) {
   return (
-    <div className="flex flex-col items-start gap-1.5 sm:flex-row sm:items-center sm:justify-between sm:gap-4">
-      <dt className="font-sans text-[11px] tracking-[0.08em] text-foreground-soft uppercase">{label}</dt>
-      <dd className="text-sm font-medium text-foreground">{value}</dd>
+    <div className="rounded-md border border-border/55 bg-surface-1/48 px-3 py-2.5 shadow-none">
+      <dt className="font-sans text-[10px] tracking-[0.1em] text-foreground-soft uppercase">{label}</dt>
+      <dd className="mt-1 truncate text-sm font-medium text-foreground">{value}</dd>
     </div>
   );
 }

--- a/src/components/shared/feed-detail-panel.tsx
+++ b/src/components/shared/feed-detail-panel.tsx
@@ -1,7 +1,10 @@
 import { ExternalLink, List } from "lucide-react";
 import type { ReactNode } from "react";
 import { workspaceCompactActionButtonClassName } from "@/components/shared/decision-button";
-import { FeedDetailCard, FeedDetailRow } from "@/components/shared/feed-detail-card";
+import {
+  FeedDetailCard,
+  FeedDetailRow,
+} from "@/components/shared/feed-detail-card";
 import { LabelChip } from "@/components/shared/label-chip";
 import { SurfaceCard } from "@/components/shared/surface-card";
 import { Button } from "@/components/ui/button";
@@ -109,12 +112,25 @@ export function FeedDetailPanel({
   primaryAction,
   secondaryAction,
 }: FeedDetailPanelProps) {
-  const resolvedTitleHref = titleHref ? normalizeFeedWebsiteUrlCandidate(titleHref) : null;
+  const resolvedTitleHref = titleHref
+    ? normalizeFeedWebsiteUrlCandidate(titleHref)
+    : null;
 
   return (
-    <FeedDetailCard data-feed-detail-panel="" className={cn("border-border/65 bg-card/38 shadow-none", className)}>
-      <div className="space-y-4">
-        <div className={cn("grid items-start gap-3", leadingVisual ? "grid-cols-[auto_minmax(0,1fr)]" : "grid-cols-1")}>
+    <FeedDetailCard
+      data-feed-detail-panel=""
+      className={cn(
+        "overflow-hidden border-border/65 bg-card/38 p-0 shadow-none",
+        className,
+      )}
+    >
+      <div className="space-y-4 border-b border-border/50 bg-surface-1/48 px-4 py-4 sm:px-5">
+        <div
+          className={cn(
+            "grid items-start gap-3",
+            leadingVisual ? "grid-cols-[auto_minmax(0,1fr)]" : "grid-cols-1",
+          )}
+        >
           {leadingVisual ? (
             <div
               data-testid="feed-detail-leading-visual"
@@ -130,32 +146,51 @@ export function FeedDetailPanel({
                   href={resolvedTitleHref}
                   target="_blank"
                   rel="noreferrer"
-                  className={cn(detailLinkClassName, "inline-flex max-w-full items-start gap-2 no-underline")}
+                  className={cn(
+                    detailLinkClassName,
+                    "inline-flex max-w-full items-start gap-2 no-underline",
+                  )}
                 >
-                  <h3 className="font-sans text-[1.6rem] font-normal tracking-[-0.03em] text-foreground">{title}</h3>
-                  <ExternalLink aria-hidden="true" className="mt-1 size-4 shrink-0" />
+                  <h3 className="font-sans text-[1.28rem] font-medium leading-tight tracking-[-0.03em] text-foreground">
+                    {title}
+                  </h3>
+                  <ExternalLink
+                    aria-hidden="true"
+                    className="mt-0.5 size-3.5 shrink-0"
+                  />
                 </a>
               ) : (
-                <h3 className="font-sans text-[1.6rem] font-normal tracking-[-0.03em] text-foreground">{title}</h3>
+                <h3 className="font-sans text-[1.28rem] font-medium leading-tight tracking-[-0.03em] text-foreground">
+                  {title}
+                </h3>
               )}
             </div>
           </div>
         </div>
+      </div>
 
+      <div className="space-y-4 px-4 py-4 sm:px-5">
         <div data-testid="feed-detail-secondary-column" className="space-y-3">
           {badgeLabel ? (
             <LabelChip
               data-testid="feed-detail-status"
               tone={resolveBadgeClassName(badgeTone)}
-              className="self-start rounded-md px-2.5 py-1 text-[10px] tracking-[0.02em]"
+              className="self-start rounded-md px-2 py-0.5 text-[10px] tracking-[0.08em]"
             >
               {badgeLabel}
             </LabelChip>
           ) : null}
 
           {summaryText ? (
-            <SurfaceCard variant="info" tone="subtle" padding="compact" className="bg-surface-1/76 shadow-none">
-              <p className="font-serif text-[0.98rem] leading-7 text-foreground-soft">{summaryText}</p>
+            <SurfaceCard
+              variant="info"
+              tone="subtle"
+              padding="compact"
+              className="bg-surface-1/76 shadow-none"
+            >
+              <p className="font-serif text-[0.98rem] leading-7 text-foreground-soft">
+                {summaryText}
+              </p>
             </SurfaceCard>
           ) : null}
 
@@ -174,14 +209,21 @@ export function FeedDetailPanel({
               <p className="font-sans text-[11px] font-medium tracking-[0.08em] text-current uppercase">
                 {reasonBox.title}
               </p>
-              <p className="mt-1.5 font-serif text-sm leading-6 text-current">{reasonBox.body}</p>
+              <p className="mt-1.5 font-serif text-sm leading-6 text-current">
+                {reasonBox.body}
+              </p>
             </SurfaceCard>
           ) : null}
 
           {reasonChips.length > 0 && !reasonBox ? (
             <div className="flex flex-wrap gap-2">
               {reasonChips.map((chip) => (
-                <LabelChip key={chip} tone="neutral" size="compact" className="rounded-md px-2 py-1">
+                <LabelChip
+                  key={chip}
+                  tone="neutral"
+                  size="compact"
+                  className="rounded-md px-2 py-1"
+                >
                   {chip}
                 </LabelChip>
               ))}
@@ -190,26 +232,46 @@ export function FeedDetailPanel({
         </div>
 
         <div className="grid gap-3">
-          <dl className="grid gap-3 border-t border-border/55 pt-3 text-sm">
+          <dl className="grid gap-2.5 border-t border-border/55 pt-3 text-sm sm:grid-cols-2">
             {metrics.map((metric) => (
-              <FeedDetailRow key={String(metric.label)} label={metric.label} value={metric.value} />
+              <FeedDetailRow
+                key={String(metric.label)}
+                label={metric.label}
+                value={metric.value}
+              />
             ))}
           </dl>
 
           {links.length > 0 ? (
             <div className="grid gap-2 text-sm">
               {links.map((link) => (
-                <a key={link.href} href={link.href} target="_blank" rel="noreferrer" className={detailLinkClassName}>
-                  <ExternalLink aria-hidden="true" className="size-4 shrink-0" />
-                  <span className="underline decoration-border underline-offset-4">{link.label}</span>
+                <a
+                  key={link.href}
+                  href={link.href}
+                  target="_blank"
+                  rel="noreferrer"
+                  className={detailLinkClassName}
+                >
+                  <ExternalLink
+                    aria-hidden="true"
+                    className="size-4 shrink-0"
+                  />
+                  <span className="underline decoration-border underline-offset-4">
+                    {link.label}
+                  </span>
                 </a>
               ))}
             </div>
           ) : null}
 
           {recentArticles.length > 0 ? (
-            <div data-testid="feed-detail-recent-articles" className="space-y-2 border-t border-border/55 pt-3">
-              <h4 className="font-sans text-sm font-medium text-foreground">{recentArticlesHeading}</h4>
+            <div
+              data-testid="feed-detail-recent-articles"
+              className="space-y-2 border-t border-border/55 pt-3"
+            >
+              <h4 className="font-sans text-sm font-medium text-foreground">
+                {recentArticlesHeading}
+              </h4>
               <div className="space-y-1">
                 {recentArticles.map((article) => (
                   <SurfaceCard
@@ -225,19 +287,27 @@ export function FeedDetailPanel({
                           href={article.url}
                           target="_blank"
                           rel="noreferrer"
-                          className={cn(detailLinkClassName, "line-clamp-2 no-underline")}
+                          className={cn(
+                            detailLinkClassName,
+                            "line-clamp-2 no-underline",
+                          )}
                         >
                           <span className="font-serif text-[0.88rem] font-normal leading-5 text-foreground">
                             {article.title}
                           </span>
-                          <ExternalLink aria-hidden="true" className="mt-0.5 size-3.5 shrink-0" />
+                          <ExternalLink
+                            aria-hidden="true"
+                            className="mt-0.5 size-3.5 shrink-0"
+                          />
                         </a>
                       ) : (
                         <span className="line-clamp-2 font-serif text-[0.88rem] font-normal leading-5 text-foreground">
                           {article.title}
                         </span>
                       )}
-                      <span className="shrink-0 text-xs text-foreground-soft">{article.publishedAt}</span>
+                      <span className="shrink-0 text-xs text-foreground-soft">
+                        {article.publishedAt}
+                      </span>
                     </div>
                   </SurfaceCard>
                 ))}
@@ -247,15 +317,15 @@ export function FeedDetailPanel({
         </div>
 
         {primaryAction || secondaryAction ? (
-          <div className="flex flex-wrap gap-3 border-t border-border/55 pt-4">
+          <div className="flex flex-wrap items-center justify-end gap-2 border-t border-border/55 pt-3">
             {primaryAction ? (
               <Button
                 aria-label={primaryAction.ariaLabel ?? primaryAction.label}
                 variant="outline"
-                size="lg"
+                size="sm"
                 className={cn(
                   workspaceCompactActionButtonClassName,
-                  "w-full border-border-strong bg-surface-1/88 text-foreground-soft shadow-none hover:bg-surface-2 hover:text-foreground",
+                  "min-h-9 w-auto border-border/70 bg-surface-1/72 px-3 text-[12px] text-foreground-soft shadow-none hover:bg-surface-2 hover:text-foreground",
                 )}
                 onClick={primaryAction.onClick}
               >
@@ -264,7 +334,12 @@ export function FeedDetailPanel({
               </Button>
             ) : null}
             {secondaryAction ? (
-              <Button variant="ghost" size="sm" className="min-h-11 px-4" onClick={secondaryAction.onClick}>
+              <Button
+                variant="ghost"
+                size="sm"
+                className="min-h-11 px-4"
+                onClick={secondaryAction.onClick}
+              >
                 {secondaryAction.label}
               </Button>
             ) : null}


### PR DESCRIPTION
### Motivation
- Reduce the visual weight of the right-hand detail panel so copy-heavy content isn't overwhelmed by oversized actions and loose spacing. 
- Make the detail surface read as a composed header + body so the title, status, summary, metrics, and actions are clearer and more compact.

### Description
- Reworked `FeedDetailPanel` to a header/body composition by splitting the title/leading visual into a quiet header and moving metadata into a denser body area. 
- Reduced title size and weight and adjusted the leading visual sizing and border tokens for a calmer appearance.
- Converted metric rows into compact `FeedDetailRow` cards (`src/components/shared/feed-detail-card.tsx`) that are rounded, bordered, and have denser padding and truncation behavior. 
- Changed the primary management action from a full-width large button to a compact trailing `sm` outline button and adjusted secondary action sizing/placement to be right-aligned. 
- Adjusted layout for metrics to use a denser two-column grid on larger breakpoints and tightened various spacing and token usages. 
- Updated the `FeedDetailPanel` unit test expectations to match the new structure and sizing (`src/__tests__/components/feed-detail-panel.test.tsx`).

### Testing
- Ran the focused jsdom unit tests: `pnpm exec vitest run --project jsdom src/__tests__/components/feed-detail-panel.test.tsx src/__tests__/components/article-view.test.tsx` and the targeted suites passed after updates. 
- Ran lint and type checks: `pnpm exec biome lint src/components/shared/feed-detail-panel.tsx src/components/shared/feed-detail-card.tsx src/__tests__/components/feed-detail-panel.test.tsx` and `pnpm exec tsc --noEmit`, both succeeded. 
- Attempted full repository gate `mise run check`, but the Rust/Tauri checks failed in this environment due to missing system `glib-2.0` / `pkg-config` libraries, and the node suite earlier reported unrelated hook timeouts (environmental). 
- Attempted Playwright screenshot capture, but Chromium could not launch in this container due to missing `libatk-1.0.so.0`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a3bb52fce74832fb903d331bf2d3eea)