### PR TITLE
Improve subscriptions tree breakdown UI

### DIFF
--- a/src/__tests__/components/subscriptions-index-page.test.tsx
+++ b/src/__tests__/components/subscriptions-index-page.test.tsx
@@ -374,8 +374,10 @@ describe("SubscriptionsIndexPage", () => {
     expect(firstGroupButton).toHaveClass("motion-disclosure-trigger");
     expect(firstGroupButton.className).toMatch(/rounded-(md|lg|xl)/);
     expect(secondGroupButton.className).toMatch(/rounded-(md|lg|xl)/);
-    expect(firstGroupButton).not.toHaveClass("border");
-    expect(screen.getByTestId("subscriptions-folder-tree-rail-folder-1")).toHaveClass("border-l");
+    expect(firstGroupButton).toHaveClass("border", "border-transparent");
+    expect(screen.getByTestId("subscriptions-folder-tree-rail-folder-1")).toHaveClass(
+      "before:bg-[color:var(--subscriptions-list-tree-rail)]",
+    );
   });
 
   it("collapses and re-expands a single group while keeping the current detail selection", async () => {

--- a/src/__tests__/components/subscriptions-list-pane.test.tsx
+++ b/src/__tests__/components/subscriptions-list-pane.test.tsx
@@ -230,12 +230,12 @@ describe("SubscriptionsListPane", () => {
     expect(folderButton).toHaveAttribute("aria-expanded", "true");
     expect(folderButton).toHaveAttribute("aria-controls", "subscriptions-group-panel-__ungrouped__");
     expect(folderButton).toHaveClass("min-h-11");
-    expect(folderButton).not.toHaveClass("border");
+    expect(folderButton).toHaveClass("border", "border-transparent");
     expect(folderButton).toHaveTextContent("1");
 
     const rail = screen.getByTestId("subscriptions-folder-tree-rail-ungrouped");
-    expect(rail).toHaveClass("border-l");
-    expect(rail).toHaveClass("pl-3");
+    expect(rail).toHaveClass("before:bg-[color:var(--subscriptions-list-tree-rail)]");
+    expect(rail).toHaveClass("pl-5");
   });
 
   it("keeps collapsed folder panels hidden and inert", () => {

--- a/src/components/subscriptions-index/subscriptions-list-pane.tsx
+++ b/src/components/subscriptions-index/subscriptions-list-pane.tsx
@@ -1,4 +1,4 @@
-import { ChevronDown, Search, X } from "lucide-react";
+import { ChevronDown, FolderOpen, Search, X } from "lucide-react";
 import { useCallback, useEffect, useId, useRef } from "react";
 import {
   MOTION_CONTENT_SWAP_CLASS_NAME,
@@ -71,17 +71,19 @@ export function SubscriptionGroupDisclosureButton({
       aria-controls={controlsId}
       onClick={() => onToggleGroup(group.key)}
       className={cn(
-        "motion-disclosure-trigger flex min-h-11 w-full items-center justify-between rounded-md px-2 py-1.5 text-left text-foreground transition-[background-color,color,box-shadow] duration-150 hover:bg-[color:var(--subscriptions-list-row-hover)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-border-strong/45 motion-reduce:transition-none",
-        !expanded && "text-foreground-soft",
+        "motion-disclosure-trigger flex min-h-11 w-full items-center justify-between rounded-md border border-transparent px-2.5 py-1.5 text-left text-foreground transition-[background-color,border-color,color,box-shadow] duration-150 hover:border-[color:var(--subscriptions-list-divider)] hover:bg-[color:var(--subscriptions-list-row-hover)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-border-strong/45 motion-reduce:transition-none",
+        expanded
+          ? "bg-[color:var(--subscriptions-list-group-surface)] shadow-[var(--subscriptions-list-group-collapsed-shadow)]"
+          : "text-foreground-soft",
       )}
     >
-      <span className="flex min-w-0 items-center gap-1.5">
-        <ChevronDown
-          className={cn(
-            "motion-disclosure-icon h-3 w-3 shrink-0 text-foreground-soft",
-            expanded ? "rotate-0" : "-rotate-90",
-          )}
-        />
+      <span className="flex min-w-0 items-center gap-2">
+        <span className="relative flex h-6 w-6 shrink-0 items-center justify-center rounded-md bg-surface-2/70 text-foreground-soft">
+          <ChevronDown
+            className={cn("motion-disclosure-icon h-3 w-3 shrink-0", expanded ? "rotate-0" : "-rotate-90")}
+          />
+        </span>
+        <FolderOpen aria-hidden="true" className="h-4 w-4 shrink-0 text-foreground-soft" />
         <h3 className="min-w-0 truncate text-[0.88rem] font-semibold tracking-[-0.01em]">{group.label}</h3>
       </span>
       <LabelChip tone="neutral" size="compact" className="shrink-0 bg-surface-1/70 text-[0.72rem]">
@@ -114,7 +116,10 @@ export function SubscriptionsListPane({
 }: SubscriptionsListPaneProps) {
   const headingId = useId();
   const scrollRegionRef = useRef<HTMLDivElement | null>(null);
-  const restoredScrollStateRef = useRef<{ scrollTop: number; resetKey: number } | null>(null);
+  const restoredScrollStateRef = useRef<{
+    scrollTop: number;
+    resetKey: number;
+  } | null>(null);
   const pendingScrollTopRef = useRef<number | null>(null);
   const committedScrollTopRef = useRef<number | null>(null);
   const scrollCommitTimerRef = useRef<number | null>(null);
@@ -250,7 +255,7 @@ export function SubscriptionsListPane({
             const groupBodyId = `subscriptions-group-panel-${group.key}`;
 
             return (
-              <div key={group.key} className="space-y-1.5">
+              <div key={group.key} className="relative space-y-1.5">
                 <SubscriptionGroupDisclosureButton
                   group={group}
                   expanded={expanded}
@@ -259,7 +264,9 @@ export function SubscriptionsListPane({
                 />
                 <div
                   id={groupBodyId}
-                  {...{ [MOTION_DATA_STATE_ATTRIBUTE]: expanded ? MOTION_STATE_OPEN : MOTION_STATE_CLOSED }}
+                  {...{
+                    [MOTION_DATA_STATE_ATTRIBUTE]: expanded ? MOTION_STATE_OPEN : MOTION_STATE_CLOSED,
+                  }}
                   aria-hidden={expanded ? "false" : "true"}
                   inert={expanded ? undefined : true}
                   className="motion-disclosure-panel"
@@ -267,7 +274,7 @@ export function SubscriptionsListPane({
                   <div className="motion-disclosure-body">
                     <div
                       data-testid={`subscriptions-folder-tree-rail-${group.folderId ?? "ungrouped"}`}
-                      className="space-y-2 border-l border-[color:var(--subscriptions-list-divider)] pl-3 pt-2"
+                      className="relative ml-5 space-y-2 pl-5 pt-2 before:absolute before:bottom-5 before:left-0 before:top-0 before:w-px before:bg-[color:var(--subscriptions-list-tree-rail)] before:content-['']"
                     >
                       {group.rows.map((row) => {
                         const isSelected = selectedFeedId === row.feed.id;
@@ -316,11 +323,21 @@ export function SubscriptionsListPane({
                                 <LabelChip tone={resolveStatusTone(row.status.labelKey)} size="compact">
                                   {statusLabels[row.status.labelKey]}
                                 </LabelChip>
-                                <span aria-hidden="true" style={{ color: "var(--subscriptions-list-meta-divider)" }}>
+                                <span
+                                  aria-hidden="true"
+                                  style={{
+                                    color: "var(--subscriptions-list-meta-divider)",
+                                  }}
+                                >
                                   •
                                 </span>
                                 <span>{formatUnreadCountLabel(row.feed.unread_count)}</span>
-                                <span aria-hidden="true" style={{ color: "var(--subscriptions-list-meta-divider)" }}>
+                                <span
+                                  aria-hidden="true"
+                                  style={{
+                                    color: "var(--subscriptions-list-meta-divider)",
+                                  }}
+                                >
                                   •
                                 </span>
                                 <span>{formatLatestArticleLabel(row.latestArticleAt)}</span>
@@ -329,14 +346,28 @@ export function SubscriptionsListPane({
                           />
                         );
 
+                        const treeRow = (
+                          <div key={`${row.feed.id}-tree-row`} className="relative">
+                            <span
+                              aria-hidden="true"
+                              className="absolute left-[-1.25rem] top-1/2 h-px w-4 bg-[color:var(--subscriptions-list-tree-rail)]"
+                            />
+                            <span
+                              aria-hidden="true"
+                              className="absolute left-[-1.3125rem] top-1/2 h-1.5 w-1.5 -translate-x-1/2 -translate-y-1/2 rounded-full border border-[color:var(--subscriptions-list-tree-node-border)] bg-[color:var(--subscriptions-list-tree-node-surface)]"
+                            />
+                            {rowButton}
+                          </div>
+                        );
+
                         return row.reasonTooltipKey ? (
                           <TooltipProvider key={row.feed.id}>
                             <AppTooltip label={reasonTooltipLabels[row.reasonTooltipKey]} side="top" align="start">
-                              {rowButton}
+                              {treeRow}
                             </AppTooltip>
                           </TooltipProvider>
                         ) : (
-                          <div key={row.feed.id}>{rowButton}</div>
+                          <div key={row.feed.id}>{treeRow}</div>
                         );
                       })}
                     </div>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -233,6 +233,9 @@
   --subscriptions-list-surface: rgba(242, 241, 237, 0.42);
   --subscriptions-detail-surface: rgba(235, 234, 229, 0.5);
   --subscriptions-list-divider: rgba(38, 37, 30, 0.12);
+  --subscriptions-list-tree-rail: rgba(38, 37, 30, 0.2);
+  --subscriptions-list-tree-node-border: rgba(38, 37, 30, 0.22);
+  --subscriptions-list-tree-node-surface: rgba(247, 247, 244, 0.92);
   --subscriptions-list-favicon-surface: rgba(247, 247, 244, 0.88);
   --subscriptions-list-favicon-surface-muted: rgba(235, 234, 229, 0.88);
   --subscriptions-list-meta-divider: rgba(38, 37, 30, 0.25);
@@ -497,6 +500,9 @@
   --subscriptions-list-surface: rgba(28, 25, 21, 0.34);
   --subscriptions-detail-surface: rgba(35, 31, 26, 0.44);
   --subscriptions-list-divider: rgba(243, 239, 230, 0.12);
+  --subscriptions-list-tree-rail: rgba(243, 239, 230, 0.2);
+  --subscriptions-list-tree-node-border: rgba(243, 239, 230, 0.22);
+  --subscriptions-list-tree-node-surface: rgba(34, 30, 25, 0.92);
   --subscriptions-list-favicon-surface: rgba(34, 30, 25, 0.9);
   --subscriptions-list-favicon-surface-muted: rgba(45, 40, 34, 0.88);
   --subscriptions-list-meta-divider: rgba(243, 239, 230, 0.25);
@@ -1048,8 +1054,9 @@ html.vertical-wipe-transition::view-transition-new(root) {
 
 .motion-resize-surface {
   transition-property:
-    width, height, min-height, max-width, max-height, padding, grid-template-columns, grid-template-rows, opacity,
-    transform, border-color, background-color, color;
+    width, height, min-height, max-width, max-height, padding,
+    grid-template-columns, grid-template-rows, opacity, transform, border-color,
+    background-color, color;
   transition-duration: var(--motion-duration-resize);
   transition-timing-function: var(--motion-ease-emphasized);
   will-change: width, height, min-height, max-width, max-height;


### PR DESCRIPTION
### Motivation

- Make folder rows read as clear parent nodes so the subscriptions list reads like a hierarchical tree rather than a flat list. 
- Surface expanded folder state and provide stronger visual affordance for disclosure and drag/drop targets. 
- Add a tokenized tree rail and node visuals so the breakdown works in both light and dark themes and follows design token policies.

### Description

- Update `src/components/subscriptions-index/subscriptions-list-pane.tsx` to add a folder icon, change disclosure button styling to use a bordered/active surface, and render a visible branch connector and node marker for child feed rows. 
- Add a per-row `key` for the generated tree-row wrapper and tidy up small JSX/format changes to keep readability and linters happy. 
- Add new CSS tokens in `src/styles/global.css` (`--subscriptions-list-tree-rail`, `--subscriptions-list-tree-node-border`, `--subscriptions-list-tree-node-surface`) with light/dark variants and apply them via pseudo elements and utility classes. 
- Update jsdom unit tests in `src/__tests__/components/subscriptions-list-pane.test.tsx` and `src/__tests__/components/subscriptions-index-page.test.tsx` to assert the revised disclosure structure, rail, and classes.

### Testing

- Ran `node ./node_modules/@biomejs/biome/bin/biome check --formatter-enabled=true --linter-enabled=true src/components/subscriptions-index/subscriptions-list-pane.tsx src/styles/global.css src/__tests__/components/subscriptions-list-pane.test.tsx src/__tests__/components/subscriptions-index-page.test.tsx` and the focused checks completed without remaining formatting/lint errors for the changed files. 
- Ran jsdom unit tests with `node ./node_modules/vitest/vitest.mjs run --project jsdom src/__tests__/components/subscriptions-list-pane.test.tsx src/__tests__/components/subscriptions-index-page.test.tsx` and the two test files passed (all tests green). 
- Ran TypeScript compile check with `node ./node_modules/typescript/bin/tsc --noEmit` which completed with no type errors. 
- Attempted the repository-wide `mise run check` and a Playwright screenshot run; both were blocked by the environment (Node version resolution and missing native libraries / DBus dependencies in this container) so full `mise` and browser E2E verification were not completed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a3bb4dd0e88832f8690257bb36b3bb2)