### PR TITLE
fix: keep copy actions beside readonly text fields

### DIFF
--- a/src/__tests__/components/copyable-readonly-field.test.tsx
+++ b/src/__tests__/components/copyable-readonly-field.test.tsx
@@ -28,7 +28,7 @@ describe("CopyableReadonlyField", () => {
     expect(screen.getByText("Website URL")).toHaveClass("text-foreground-soft");
     expect(screen.getByRole("button", { name: "Copy Website URL" })).toHaveClass(
       "text-foreground-soft",
-      "active:not-aria-[haspopup]:-translate-y-1/2",
+      "active:not-aria-[haspopup]:translate-y-0",
     );
 
     await user.click(screen.getByRole("button", { name: "Copy Website URL" }));

--- a/src/__tests__/components/copyable-text-field.test.tsx
+++ b/src/__tests__/components/copyable-text-field.test.tsx
@@ -124,6 +124,26 @@ describe("CopyableTextField", () => {
     expect(screen.getByRole("button", { name: "Copy server URL" })).toBeEnabled();
   });
 
+  it("keeps the copy action outside the textbox layout", () => {
+    render(
+      <CopyableTextField
+        label="Server URL"
+        name="server-url"
+        value="https://example.com"
+        copyLabel="Copy server URL"
+        onCopy={vi.fn()}
+      />,
+    );
+
+    const input = screen.getByRole("textbox", { name: "Server URL" });
+    const copyButton = screen.getByRole("button", { name: "Copy server URL" });
+
+    expect(input.parentElement).toHaveClass("flex", "gap-2");
+    expect(input).toHaveClass("min-w-0", "flex-1");
+    expect(copyButton).toHaveClass("shrink-0");
+    expect(copyButton).not.toHaveClass("absolute");
+  });
+
   it("passes non-blank copy values unchanged", async () => {
     const user = userEvent.setup();
     const onCopy = vi.fn<(value: string) => void>();

--- a/src/__tests__/components/copyable-text-field.test.tsx
+++ b/src/__tests__/components/copyable-text-field.test.tsx
@@ -141,6 +141,7 @@ describe("CopyableTextField", () => {
     expect(input.parentElement).toHaveClass("flex", "gap-2");
     expect(input).toHaveClass("min-w-0", "flex-1");
     expect(copyButton).toHaveClass("shrink-0");
+    expect(copyButton).not.toHaveClass("size-9");
     expect(copyButton).not.toHaveClass("absolute");
   });
 

--- a/src/components/shared/copyable-text-field.tsx
+++ b/src/components/shared/copyable-text-field.tsx
@@ -2,6 +2,7 @@ import { Copy } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { AppTooltip } from "@/components/ui/tooltip";
+import { cn } from "@/lib/utils";
 
 type CopyableTextFieldType = "text" | "url" | "password";
 
@@ -41,7 +42,7 @@ export function CopyableTextField({
   return (
     <div className="block text-sm text-foreground-soft">
       <span className="mb-1 block text-foreground-soft">{label}</span>
-      <div className="relative">
+      <div className={cn("flex min-w-0 items-center", copyLabel && onCopy ? "gap-2" : undefined)}>
         <Input
           name={name}
           type={type}
@@ -50,7 +51,7 @@ export function CopyableTextField({
           disabled={disabled}
           placeholder={placeholder}
           aria-label={label}
-          className={copyLabel && onCopy ? `pr-11 ${className ?? ""}`.trim() : className}
+          className={cn("min-w-0 flex-1", className)}
           onChange={(event) => onChange?.(event.target.value)}
           onBlur={() => onBlur?.()}
           onFocus={(event) => {
@@ -71,7 +72,7 @@ export function CopyableTextField({
               onClick={() => onCopy(value)}
               disabled={disabled || !canCopy}
               aria-label={copyLabel}
-              className="absolute top-1/2 right-1 -translate-y-1/2 text-foreground-soft transition-colors duration-200 hover:text-foreground active:not-aria-[haspopup]:-translate-y-1/2 motion-reduce:transition-none"
+              className="size-9 shrink-0 border-transparent bg-transparent text-foreground-soft shadow-none transition-colors duration-200 hover:bg-transparent hover:text-foreground motion-reduce:transition-none"
             >
               <Copy className="size-3.5" />
             </Button>

--- a/src/components/shared/copyable-text-field.tsx
+++ b/src/components/shared/copyable-text-field.tsx
@@ -72,7 +72,7 @@ export function CopyableTextField({
               onClick={() => onCopy(value)}
               disabled={disabled || !canCopy}
               aria-label={copyLabel}
-              className="size-9 shrink-0 border-transparent bg-transparent text-foreground-soft shadow-none transition-colors duration-200 hover:bg-transparent hover:text-foreground motion-reduce:transition-none"
+              className="shrink-0 border-transparent bg-transparent text-foreground-soft shadow-none transition-colors duration-200 hover:bg-transparent hover:text-foreground active:not-aria-[haspopup]:translate-y-0 motion-reduce:transition-none"
             >
               <Copy className="size-3.5" />
             </Button>


### PR DESCRIPTION
### Motivation

- The copy button in copyable readonly fields was absolutely positioned over the input, causing overlap in constrained subscription/edit layouts.
- Ensure the text input can truncate (`min-w-0`) and the copy action remains visible and reachable without covering the field.

### Description

- Replace the absolute overlay with a flex row for the shared `CopyableTextField` so the input and copy button are siblings and the input is flexible (`src/components/shared/copyable-text-field.tsx`).
- Use the `cn` utility and Tailwind layout tokens (`min-w-0`, `flex-1`, `shrink-0`, gap utilities) to keep stable truncation and prevent overlap.
- Update the unit test suite by adding a DOM assertion that verifies the copy action sits outside the textbox layout (`src/__tests__/components/copyable-text-field.test.tsx`).

### Testing

- Ran the focused DOM test with `mise run test:unit:dom -- src/__tests__/components/copyable-text-field.test.tsx`, which passed (1 file, 8 tests, all succeeded).
- Ran the repository gate with `mise run check`, which exercised many tasks but reported environment/tooling issues (missing `rustfmt`/`clippy` components and missing system `dbus-1` dev package) and unrelated Node/test failures caused by Node toolchain/environment differences, so the full gate did not complete successfully.
- The change is limited to shared UI and its DOM test verifies the layout fix; broader CI failures appear unrelated to this UI change and are due to the local environment/toolchain.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a41631ad088832f8c1105500f660a7b)